### PR TITLE
modification pour tenir compte des proxies HTTPS

### DIFF
--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -501,7 +501,7 @@ class plxUtils {
 	 **/
 	public static function getRacine() {
 
-		$protocol = (!empty($_SERVER['HTTPS']) AND $_SERVER['HTTPS'] == 'on')?	'https://' : "http://";
+		$protocol = (!empty($_SERVER['HTTPS']) AND strtolower($_SERVER['HTTPS']) == 'on') || (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) AND strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https' )?        'https://' : "http://";
 		$servername = $_SERVER['HTTP_HOST'];
 		$serverport = (preg_match('/:[0-9]+/', $servername) OR $_SERVER['SERVER_PORT'])=='80' ? '' : ':'.$_SERVER['SERVER_PORT'];
 		$dirname = preg_replace('/\/(core|plugins)\/(.*)/', '', dirname($_SERVER['SCRIPT_NAME']));


### PR DESCRIPTION
ajout de la constante $_SERVER['HTTP_X_FORWARDED_PROTO'] dans la définition de la variable $protocol afin de tenir compte des reverse-proxies HTTPS (pound, HAproxy, etc) afin que les thèmes soient correctement appliqué en https avec ces configurations.
ajout de la fonction strtolower() afin d'éviter tout problème de formatage.
