### PR TITLE
Correction d'une possible auth-bypass

### DIFF
--- a/core/admin/auth.php
+++ b/core/admin/auth.php
@@ -62,7 +62,7 @@ if(!empty($_GET['d']) AND $_GET['d']==1) {
 if(!empty($_POST['login']) AND !empty($_POST['password'])) {
 	$connected = false;
 	foreach($plxAdmin->aUsers as $userid => $user) {
-		if ($_POST['login']==$user['login'] AND sha1($user['salt'].md5($_POST['password']))==$user['password'] AND $user['active'] AND !$user['delete']) {
+		if ($_POST['login']==$user['login'] AND sha1($user['salt'].md5($_POST['password']))===$user['password'] AND $user['active'] AND !$user['delete']) {
 			$_SESSION['user'] = $userid;
 			$_SESSION['profil'] = $user['profil'];
 			$_SESSION['hash'] = plxUtils::charAleatoire(10);


### PR DESCRIPTION
Php a tendance a caster les strings en integer lors de leur comparaison.
Par exemple, ii le hash d'un utilisateur commence par "0e", il sera égal à "0", ainsi qu'un n'importe quel hash commençant pas "0e".
