### PR TITLE
fix bug d'affichage en cas d'erreur url/date a la creation d'un article

### DIFF
--- a/core/admin/article.php
+++ b/core/admin/article.php
@@ -113,7 +113,10 @@ if(!empty($_POST)) { # Création, mise à jour, suppression ou aperçu
 			$plxAdmin->editArticle($_POST,$_POST['artId']);
 			header('Location: article.php?a='.$_POST['artId']);
 			exit;
-		}
+		# Si url ou date invalide, on ne sauvegarde pas mais on repasse en mode brouillon
+    }else{
+      array_unshift($_POST['catId'], 'draft');
+    }
 
 	}
 	# Ajout d'une catégorie


### PR DESCRIPTION
lorsque l'on cliquait sur le bouton publier alors que l'url existait
déja, le bouton "publier" disparait et l'état devient "publié" alors
qu'il y a un message d'erreur bloquant la publication.
