### PR TITLE
Proposition pour le style des tableaux dans l'administration

### DIFF
--- a/core/admin/theme/plucss.css
+++ b/core/admin/theme/plucss.css
@@ -219,7 +219,7 @@ table {
 }
 td,
 th {
-	border: 1px solid #bbb;
+	border: 1px solid #ddd;
 	height: 1.9rem;
 	padding-left: .4rem;
 	padding-right: .4rem;
@@ -228,8 +228,12 @@ tfoot,
 thead {
 	background-color: #ddd;
 }
+tr:nth-child(even) {
+    background-color: #EEE;
+}
+
 tr:hover {
-	background-color: #fff8dc;
+	background-color: #fff8dc!important;
 }
 tfoot tr:hover,
 thead tr:hover {


### PR DESCRIPTION
![2015-02-18_screenshot_001](https://cloud.githubusercontent.com/assets/4021867/6239963/9c6c9222-b709-11e4-97c0-ab6e63fe0960.png)

Bonjour, 

En testant Pluxml-master ( vraiment super boulot dans l'ensemble !) , ce qui m'a choqué ce sont les tableaux aux rebords foncés et sans alternance de fonds. Sur les versions précédentes c'était très épuré et de loin plus lisible à mon goût.  

Ce 'pull request' essaie donc de corriger cette aspect, et de faire un compromis entre de beaux tableaux pour plucss ( qui pourront être utilisé en dehors , en gardant un contour à toutes les cellules ) et un aspect un peu plus clean pour l'administration de Pluxml, comme sur la copie d'écran en en-tête de ce message. ( references : tableaux en bas de cette page: https://support.google.com/youtube/answer/1722171 )
  
Un regret cependant dans mon 'commit' ;
```
tr:nth-child(even) {
    background-color: #EEE;
```
Est une bonne astuce pour retrouver l'alternance des fonds de tableaux en CSS ( source: http://stackoverflow.com/questions/3084261/alternate-table-row-color-using-css ). Malheuresement, pour garder le fond alternatif en :hover, j'ai du utiliser !important:
 ```
tr:hover {
	background-color: #fff8dc!important;
```
Ce qui n'est pas élégant, mais fonctionne. Je suis ouvert à toutes meilleures solution.