### PR TITLE
Fix PHP Fatal error in PHP 7.0

### DIFF
--- a/core/lib/class.plx.plugins.php
+++ b/core/lib/class.plx.plugins.php
@@ -87,7 +87,7 @@ class plxPlugins {
 				if($callback['class']=='=SHORTCODE=') {
 					echo $callback['method'];
 				} else {
-					$return = $this->aPlugins[$callback['class']]->$callback['method']($parms);
+					$return = $this->aPlugins[$callback['class']]->{$callback['method']}($parms);
 				}
 			}
 			if(isset($return))

--- a/core/lib/class.plx.plugins.php
+++ b/core/lib/class.plx.plugins.php
@@ -632,4 +632,3 @@ class plxPlugin {
 	}
 
 }
-?>


### PR DESCRIPTION
PHP Fatal error:  Uncaught Error: Function name must be a string
Sorry for the 

Full stack trace: 

PHP message: PHP Notice:  Array to string conversion in /core/lib/class.plx.plugins.php on line 92
PHP message: PHP Notice:  Undefined property: plxMyBetterUrls::$Array in /core/lib/class.plx.plugins.php on line 92
PHP message: PHP Fatal error:  Uncaught Error: Function name must be a string in /core/lib/class.plx.plugins.php:92
Stack trace:
#0 /core/lib/class.plx.motor.php(106): plxPlugins->callHook('plxMotorConstru...')
#1 /core/lib/class.plx.motor.php(54): plxMotor->__construct('./data/configur...')
#2 /index.php(42): plxMotor::getInstance()
#3 {main}
  thrown in /core/lib/class.plx.plugins.php on line 92