### PR TITLE
Optimisation appel mediasManager pour image d'accroche

### DIFF
--- a/core/admin/foot.php
+++ b/core/admin/foot.php
@@ -12,7 +12,7 @@
 		windowName : "<?php echo L_MEDIAS_TITLE ?>",
 		racine:	"<?php echo plxUtils::getRacine() ?>",
 		root: "<?php echo PLX_ROOT ?>",
-		urlManager: "<?php echo PLX_CORE ?>admin/medias.php",
+		urlManager: "core/admin/medias.php"
 	});
 </script>
 


### PR DESCRIPTION
Image d'accroche dans article.php:
Pour lancer le **mediaManager**, il est préférable de donner une adresse url absolue à **urlManager**, ou une adresse relative par rapport à racine.
Le remplacement de **onclick** dans medias.php est très lourd. En utilisant **addEventListener** sur tbody, on simplifie bien les choses.
Avant d'appeler **callback**, il est plus pertinent de vérifier que c'est bien une **function** plutôt que de vérifier que la valeur n'est pas une chaine vide.