### PR TITLE
Test lib XML à l'installation

### DIFF
--- a/core/lang/de/core.php
+++ b/core/lang/de/core.php
@@ -75,6 +75,8 @@ $LANG = array(
 'L_MODREWRITE_NOT_AVAILABLE'=> 'mod_rewrite APACHE-Modul ist nicht verfügbar',
 'L_LIBGD_INSTALLED'			=> 'GD Grafikbibliothek ist verfügbar',
 'L_LIBGD_NOT_INSTALLED'		=> 'GD Grafikbibliothek ist nicht verfügbar',
+'L_LIBXML_INSTALLED'		=> 'XML Grafikbibliothek ist verfügbar',
+'L_LIBXML_NOT_INSTALLED'	=> 'XML Grafikbibliothek ist nicht verfügbar',
 'L_MAIL_AVAILABLE'			=> 'E-Mail versenden ist möglich',
 'L_MAIL_NOT_AVAILABLE'		=> 'E-Mail versenden ist nicht möglich',
 

--- a/core/lang/en/core.php
+++ b/core/lang/en/core.php
@@ -75,6 +75,8 @@ $LANG = array(
 'L_MODREWRITE_NOT_AVAILABLE'	=> 'Apache URL Rewriting module mod_rewrite unavailable',
 'L_LIBGD_INSTALLED'				=> 'GD library installed',
 'L_LIBGD_NOT_INSTALLED'			=> 'GD library not installed',
+'L_LIBXML_INSTALLED'			=> 'XML library installed',
+'L_LIBXML_NOT_INSTALLED'		=> 'XML library not installed',
 'L_MAIL_AVAILABLE'				=> 'Mail sending function available',
 'L_MAIL_NOT_AVAILABLE'			=> 'Mail sending function unavailable',
 

--- a/core/lang/es/core.php
+++ b/core/lang/es/core.php
@@ -75,6 +75,8 @@ $LANG = array(
 'L_MODREWRITE_NOT_AVAILABLE'	=> 'Módulo de Apache para re-escritura de URLs («mod_rewrite») no disponible',
 'L_LIBGD_INSTALLED'				=> 'Biblioteca GD instalada',
 'L_LIBGD_NOT_INSTALLED'			=> 'Biblioteca GD no instalada',
+'L_LIBXML_INSTALLED'			=> 'Biblioteca XML instalada',
+'L_LIBXML_NOT_INSTALLED'		=> 'Biblioteca XML no instalada',
 'L_MAIL_AVAILABLE'				=> 'Función de envío de correos disponible',
 'L_MAIL_NOT_AVAILABLE'			=> 'Función de envío de correos no disponible',
 

--- a/core/lang/fr/core.php
+++ b/core/lang/fr/core.php
@@ -75,6 +75,8 @@ $LANG = array(
 'L_MODREWRITE_NOT_AVAILABLE'	=> 'Module apache de réécriture d\'url mod_rewrite non disponible',
 'L_LIBGD_INSTALLED'				=> 'Bibliothèque GD installée',
 'L_LIBGD_NOT_INSTALLED'			=> 'Bibliothèque GD non installée',
+'L_LIBXML_INSTALLED'				=> 'Bibliothèque XML installée',
+'L_LIBXML_NOT_INSTALLED'			=> 'Bibliothèque XML non installée',
 'L_MAIL_AVAILABLE'				=> 'Fonction d\'envoi de mail disponible',
 'L_MAIL_NOT_AVAILABLE'			=> 'Fonction d\'envoi de mail non disponible',
 

--- a/core/lang/it/core.php
+++ b/core/lang/it/core.php
@@ -75,6 +75,8 @@ $LANG = array(
 'L_MODREWRITE_NOT_AVAILABLE'	=> 'Modulo mod_rewrite non disponibile',
 'L_LIBGD_INSTALLED'				=> 'Biblioteca GD installata',
 'L_LIBGD_NOT_INSTALLED'			=> 'Biblioteca GD non installata',
+'L_LIBXML_INSTALLED'			=> 'Biblioteca XML installata',
+'L_LIBXML_NOT_INSTALLED'		=> 'Biblioteca XML non installata',
 'L_MAIL_AVAILABLE'				=> 'Funzione di invio mail disponible',
 'L_MAIL_NOT_AVAILABLE'			=> 'Funzione di invio mail non disponible',
 

--- a/core/lang/nl/core.php
+++ b/core/lang/nl/core.php
@@ -75,6 +75,8 @@ $LANG = array(
 'L_MODREWRITE_NOT_AVAILABLE'	=> 'Apache module mod_rewrite voor het herschrijven van URLs is niet beschikbaar',
 'L_LIBGD_INSTALLED'				=> 'GD-bibliotheek is geïnstalleerd',
 'L_LIBGD_NOT_INSTALLED'			=> 'GD-bibliotheek is niet geïnstalleerd of beschikbaar',
+'L_LIBXML_INSTALLED'			=> 'XML-bibliotheek is geïnstalleerd',
+'L_LIBXML_NOT_INSTALLED'		=> 'XML-bibliotheek is niet geïnstalleerd of beschikbaar',
 'L_MAIL_AVAILABLE'				=> 'Email verzendfunctie is beschikbaar',
 'L_MAIL_NOT_AVAILABLE'			=> 'Email verzendfunctie is niet beschikbaar',
 

--- a/core/lang/oc/core.php
+++ b/core/lang/oc/core.php
@@ -75,6 +75,8 @@ $LANG = array(
 'L_MODREWRITE_NOT_AVAILABLE'	=> 'Modul apache de reescritura d\'url mod_rewrite non disponible',
 'L_LIBGD_INSTALLED'				=> 'Bibliotèca GD installada',
 'L_LIBGD_NOT_INSTALLED'			=> 'Bibliotèca GD non installada',
+'L_LIBXML_INSTALLED'			=> 'Bibliotèca XML installada',
+'L_LIBXML_NOT_INSTALLED'		=> 'Bibliotèca XML non installada',
 'L_MAIL_AVAILABLE'				=> 'Foncion d\'enviada de mail disponible',
 'L_MAIL_NOT_AVAILABLE'			=> 'Foncion d\'enviada de mail non disponible',
 

--- a/core/lang/pl/core.php
+++ b/core/lang/pl/core.php
@@ -75,6 +75,8 @@ $LANG = array(
 'L_MODREWRITE_NOT_AVAILABLE'	=> 'Moduł apache mod_rewrite nie jest dostępny',
 'L_LIBGD_INSTALLED'				=> 'Zainstalowane biblioteki GD',
 'L_LIBGD_NOT_INSTALLED'			=> 'Nie zainstalowane biblioteki GD',
+'L_LIBXML_INSTALLED'			=> 'Zainstalowane biblioteki XML',
+'L_LIBXML_NOT_INSTALLED'		=> 'Nie zainstalowane biblioteki XML',
 'L_MAIL_AVAILABLE'				=> 'Funkcja wysyłania poczty dostępna',
 'L_MAIL_NOT_AVAILABLE'			=> 'Funkcja wysyłania poczty nie jest dostępna',
 

--- a/core/lang/pt/core.php
+++ b/core/lang/pt/core.php
@@ -75,6 +75,8 @@ $LANG = array(
 'L_MODREWRITE_NOT_AVAILABLE'	=> 'Módulo apache de reescrever URLS  "mod_rewrite" indisponivél',
 'L_LIBGD_INSTALLED'				=> 'Bibliotéca GD instalada',
 'L_LIBGD_NOT_INSTALLED'			=> 'Bibliotéca GD não instalada',
+'L_LIBXML_INSTALLED'			=> 'Bibliotéca XML instalada',
+'L_LIBXML_NOT_INSTALLED'		=> 'Bibliotéca XML não instalada',
 'L_MAIL_AVAILABLE'				=> 'Função de envio de e-mail disponivél',
 'L_MAIL_NOT_AVAILABLE'			=> 'Função de envio de e-mail indisponivél',
 

--- a/core/lang/ro/core.php
+++ b/core/lang/ro/core.php
@@ -75,6 +75,8 @@ $LANG = array(
 'L_MODREWRITE_NOT_AVAILABLE'	=> 'Apache URL Rewriting module mod_rewrite nu este disponibil',
 'L_LIBGD_INSTALLED'				=> 'Biblioteca GD este instalată',
 'L_LIBGD_NOT_INSTALLED'			=> 'Biblioteca GD nu este instalată',
+'L_LIBXML_INSTALLED'			=> 'Biblioteca XML este instalată',
+'L_LIBXML_NOT_INSTALLED'		=> 'Biblioteca XML nu este instalată',
 'L_MAIL_AVAILABLE'				=> 'Functia  de a trimite e-mail disponibilă',
 'L_MAIL_NOT_AVAILABLE'			=> 'Functia  de a trimite e-mail nu este disponibilă',
 

--- a/core/lang/ru/core.php
+++ b/core/lang/ru/core.php
@@ -75,6 +75,8 @@ $LANG = array(
 'L_MODREWRITE_NOT_AVAILABLE'	=> 'Apache URL модуля mod_rewrite недоступен',
 'L_LIBGD_INSTALLED'				=> 'GD библиотека установлена',
 'L_LIBGD_NOT_INSTALLED'			=> 'GD библиотека не установлена',
+'L_LIBXML_INSTALLED'			=> 'XML библиотека установлена',
+'L_LIBXML_NOT_INSTALLED'		=> 'XML библиотека не установлена',
 'L_MAIL_AVAILABLE'				=> 'функция отправки почты доступна',
 'L_MAIL_NOT_AVAILABLE'			=> 'Функция отправки почты недоступна',
 

--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -325,6 +325,27 @@ class plxUtils {
 	}
 
 	/**
+	 * Méthode qui teste si la bibliothèque XML est installée
+	 *
+	 * @param	format		format d'affichage
+	 *
+	 **/
+	public static function testLibXml($format="<li><span style=\"color:#color\">#symbol #message</span></li>\n") {
+
+		if(function_exists('xml_parser_create')) {
+			$output = str_replace('#color', 'green', $format);
+			$output = str_replace('#symbol', '&#10004;', $output);
+			$output = str_replace('#message', L_LIBXML_INSTALLED, $output);
+			echo $output;
+		} else {
+			$output = str_replace('#color', 'red', $format);
+			$output = str_replace('#symbol', '&#10007;', $output);
+			$output = str_replace('#message', L_LIBXML_NOT_INSTALLED, $output);
+			echo $output;
+		}
+	}
+
+	/**
 	 * Méthode qui formate une chaine de caractères en supprimant des caractères non valides
 	 *
 	 * @param	str			chaine de caractères à formater

--- a/install.php
+++ b/install.php
@@ -324,6 +324,7 @@ plxUtils::cleanHeaders();
 						<?php plxUtils::testWrite(PLX_ROOT.$config['racine_plugins']) ?>
 						<?php plxUtils::testModReWrite() ?>
 						<?php plxUtils::testLibGD() ?>
+						<?php plxUtils::testLibXml() ?>
 						<?php plxUtils::testMail() ?>
 					</ul>
 


### PR DESCRIPTION
À l'installation, la disponibilité de la bibliothèque XML n'est pas testée. La validation de l'installeur aboutit à une page blanche avec l'erreur suivante dans le log : `Call to undefined function xml_parser_create()`

J'ai ajouté le test de la bibliothèque XML sur le modèle du test de GD. Si cela convient, je rajouterai les autres traductions.