### PR TITLE
Rel2abs object

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ PluXml
 ======
 
 Principales caractéristiques
--------------------------------
+----------------------------
 
 * Aucune base de données requise
 * Portable sur clé USB
@@ -14,6 +14,12 @@ Principales caractéristiques
 * Thèmes personnalisables
 * Plugins
 * Réécriture d'url (nécessite le module apache mod_rewrite)
+
+Démonstration
+-------------
+
+* [Blog](http://demo.pluxml.org/)
+* [Administration](http://demo.pluxml.org/core/admin/auth.php?p=/core/admin/)
 
 Prérequis
 ---------

--- a/core/admin/medias.php
+++ b/core/admin/medias.php
@@ -30,10 +30,10 @@ elseif(!empty($_POST['folder'])) {
 	$_SESSION['folder'] = ($_POST['folder']=='.'?'':$_POST['folder']);
 }
 # Nouvel objet de type plxMedias
+$plxMediasRoot = PLX_ROOT.$_SESSION['medias'];
 if($plxAdmin->aConf['userfolders'] AND $_SESSION['profil']==PROFIL_WRITER)
-	$plxMedias = new plxMedias(PLX_ROOT.$_SESSION['medias'].$_SESSION['user'].'/',$_SESSION['folder']);
-else
-	$plxMedias = new plxMedias(PLX_ROOT.$_SESSION['medias'],$_SESSION['folder']);
+	$plxMediasRoot .= $_SESSION['user'].'/';
+$plxMedias = new plxMedias($plxMediasRoot, $_SESSION['folder']);
 
 #----
 

--- a/core/lib/class.plx.feed.php
+++ b/core/lib/class.plx.feed.php
@@ -234,6 +234,12 @@ class plxFeed extends plxMotor {
 		# On va boucler sur les articles (s'il y en a)
 		if($this->plxRecord_arts) {
 			while($this->plxRecord_arts->loop()) {
+				$thumb = '';
+				$src = $this->plxRecord_arts->f('thumbnail');
+				if($src!='') {
+					$src = (strpos($src, 'http')===false ? $this->racine.$src : $src);
+					$thumb = plxUtils::strCheck('<img src="'.$src.'" alt="" title="" />');
+				}
 				# Traitement initial
 				if($this->aConf['feed_chapo']) {
 					$content = $this->plxRecord_arts->f('chapo');
@@ -253,7 +259,7 @@ class plxFeed extends plxMotor {
 				$entry .= "\t\t".'<title>'.plxUtils::strCheck($this->plxRecord_arts->f('title')).'</title> '."\n";
 				$entry .= "\t\t".'<link>'.$this->urlRewrite('?article'.$artId.'/'.$this->plxRecord_arts->f('url')).'</link>'."\n";
 				$entry .= "\t\t".'<guid>'.$this->urlRewrite('?article'.$artId.'/'.$this->plxRecord_arts->f('url')).'</guid>'."\n";
-				$entry .= "\t\t".'<description>'.plxUtils::strCheck(plxUtils::rel2abs($this->racine,$content)).'</description>'."\n";
+				$entry .= "\t\t".'<description>'.$thumb.plxUtils::strCheck(plxUtils::rel2abs($this->racine,$content)).'</description>'."\n";
 				$entry .= "\t\t".'<pubDate>'.plxDate::dateIso2rfc822($this->plxRecord_arts->f('date')).'</pubDate>'."\n";
 				$entry .= "\t\t".'<dc:creator>'.plxUtils::strCheck($author).'</dc:creator>'."\n";
 				# Hook plugins

--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -722,24 +722,22 @@ class plxUtils {
 		if (substr($base, -1) != '/')
 			$base .= '/';
 
-		# réécriture des liens commençant uniquement par une ancre
-		$url = plxUtils::getRacine().plxUtils::getGets();
-		$html = preg_replace('/(href=["|\'])#/', '$1'.$url.'#', $html);
-
+		# Ne pas convertir Les liens commençant avec href="#....". Liens internes à la page !
 		# on protège tous les liens externes au site, et on transforme tous les liens relatifs en absolus
 		# on ajoute le hostname si nécessaire
 		$mask = '=<<>>=';
-		$protect = '(\#|javascript|data|callto|content|fax|file|ftp|imap|irc|jabber|mailto|mms|news|pop|sip|smb|sms|ssh|tel|telnet|vnc|xmpp):?';
-		$patterns = array('#(href|src)=("|\')('.$protect.':)#i', '#(href|src)=("|\')([a-z]+://)#i', '#(href|src)=("|\')(?:\./)?([^/])#i');
-		$replaces = array('$1'.$mask.'$2$3', '$1'.$mask.'$2$3', '$1=$2'.$base.'$3');
-		if (preg_match('#^[a-z]+://#i', $base)) {
-			$patterns[] = '#(href|src)=("|\')/([^/])#i';
-			$replaces[] = '$1=$2'.$base.'$3';
-		}
+		$patterns = array(
+			'@(href|src|<object\s[^>]*data)=("|\')(#|[a-z]+:)@i', # lien interne ou utilisation d'un protocole type href="xxxx:...." à protéger.
+			'@(href|src|<object\s[^>]*data)=("|\')(?:\./)?([^/])@i' # lieu relatif à transformer
+		);
+		$replaces = array(
+			'$1'.$mask.'$2$3',
+			'$1=$2'.$base.'$3'
+		);
 		$result = preg_replace($patterns, $replaces, $html);
+
 		# on retire la protection des liens externes. Expressions régulières lentes et inutiles
-		$result = str_replace($mask, '=', $result);
-		return $result;
+		return str_replace($mask, '=', $result);
 
 	}
 

--- a/readme/CHANGELOG
+++ b/readme/CHANGELOG
@@ -5,6 +5,7 @@
 [+] Prise en compte du fichier css des plugins sur la page auth.php
 [+] Administration : Tri ordre des catégories et des pages statiques par drag&drop
 [+]	Affichage de l'image d'accroche dans les flux rss
+[+] Thème par défaut : entête de page fixe (contribution bazooka07)
 FIX Suppression fichier plugin update impossible (droit fichier)
 FIX Chevauchement des menus de l'administration avec un facteur de zoom > 100%
 FIX Administration : mauvais affichage des caractères spéciaux dans le nom de l'auteur d'un commentaire (contribution bazooka07)

--- a/readme/CHANGELOG
+++ b/readme/CHANGELOG
@@ -4,6 +4,7 @@
 [+] #225: Ajout id à la balise <body> de la page auth.php
 [+] Prise en compte du fichier css des plugins sur la page auth.php
 [+] Administration : Tri ordre des catégories et des pages statiques par drag&drop
+[+]	Affichage de l'image d'accroche dans les flux rss
 FIX Suppression fichier plugin update impossible (droit fichier)
 FIX Chevauchement des menus de l'administration avec un facteur de zoom > 100%
 FIX Administration : mauvais affichage des caractères spéciaux dans le nom de l'auteur d'un commentaire (contribution bazooka07)

--- a/themes/defaut/css/theme.css
+++ b/themes/defaut/css/theme.css
@@ -14,11 +14,17 @@
 
 /* ----- Menu ----- */
 
+nav {
+	position: sticky;
+	top: 0;
+	z-index: 2;
+}
 .nav {
-	background-color: #fff;
+	background-color: #fbfbfb;
 	height: 4rem;
 	text-align: left;
-	margin-top: 1rem;
+	border-bottom: 1px solid #fafafa;
+	padding-top: 0.5rem;
 }
 .nav ul {
 	line-height: 3rem;


### PR DESCRIPTION
Correction de la methode plxUtils::rel2abs pour prendre en compte les balises HTML &lt;object data="..."> et &lt;a href="#...">
&lt;object> précise son Url dans l'attribut data au lieu de src ou href pour les  autres balises
&lta href="#..."> est un lien interne à la base HTML. Il n'y a pas lieu de le transformer en lien absolu.