### PR TITLE
Arch list

### DIFF
--- a/core/lang/en/core.php
+++ b/core/lang/en/core.php
@@ -33,6 +33,18 @@ $LANG = array(
 'L_SHORT_OCTOBER'				=> 'oct',
 'L_SHORT_NOVEMBER'				=> 'nov',
 'L_SHORT_DECEMBER'				=> 'dec',
+'L_LONG_JANUARY'				=> 'january  ',
+'L_LONG_FEBRUARY'				=> 'february ',
+'L_LONG_MARCH'					=> 'march    ',
+'L_LONG_APRIL'					=> 'april    ',
+'L_LONG_MAY'					=> 'may      ',
+'L_LONG_JUNE'					=> 'june     ',
+'L_LONG_JULY'					=> 'july     ',
+'L_LONG_AUGUST'					=> 'august   ',
+'L_LONG_SEPTEMBER'				=> 'september',
+'L_LONG_OCTOBER'				=> 'october  ',
+'L_LONG_NOVEMBER'				=> 'november ',
+'L_LONG_DECEMBER'				=> 'december ',
 'L_JANUARY'						=> 'january',
 'L_FEBRUARY'					=> 'february',
 'L_MARCH'						=> 'march',
@@ -128,6 +140,11 @@ $LANG = array(
 'L_PAGINATION'					=> 'page %s of %s',
 
 'L_PAGEBLOG_TITLE'				=> 'Blog',
+
+'L_YEAR'						=> 'year',
+'L_LONG_YEAR'					=> 'year     ', # same count of characters as 'L_LONG_JANUARY'
+'L_TOTAL'						=> 'Sum total',
+'L_LONG_TOTAL'					=> 'Sum total',
 
 # class.plx.feed.php
 'L_FEED_NO_PRIVATE_URL'			=> 'Private URLs have not been initialized in your administration settings!',

--- a/core/lang/fr/core.php
+++ b/core/lang/fr/core.php
@@ -33,6 +33,18 @@ $LANG = array(
 'L_SHORT_OCTOBER'				=> 'oct',
 'L_SHORT_NOVEMBER'				=> 'nov',
 'L_SHORT_DECEMBER'				=> 'déc',
+'L_LONG_JANUARY'				=> 'janvier  ',
+'L_LONG_FEBRUARY'				=> 'février  ',
+'L_LONG_MARCH'					=> 'mars     ',
+'L_LONG_APRIL'					=> 'avril    ',
+'L_LONG_MAY'					=> 'mai      ',
+'L_LONG_JUNE'					=> 'juin     ',
+'L_LONG_JULY'					=> 'juillet  ',
+'L_LONG_AUGUST'					=> 'août     ',
+'L_LONG_SEPTEMBER'				=> 'septembre',
+'L_LONG_OCTOBER'				=> 'octobre  ',
+'L_LONG_NOVEMBER'				=> 'novembre ',
+'L_LONG_DECEMBER'				=> 'décembre ',
 'L_JANUARY'						=> 'janvier',
 'L_FEBRUARY'					=> 'février',
 'L_MARCH'						=> 'mars',
@@ -128,6 +140,11 @@ $LANG = array(
 'L_PAGINATION'					=> 'page %s sur %s',
 
 'L_PAGEBLOG_TITLE'				=> 'Blog',
+
+'L_YEAR'						=> 'année',
+'L_LONG_YEAR'					=> 'année    ', # même nombre de caractères que 'L_LONG_JANUARY'
+'L_TOTAL'						=> 'Total',
+'L_LONG_TOTAL'					=> 'Total    ',
 
 # class.plx.feed.php
 'L_FEED_NO_PRIVATE_URL'			=> 'Les URLs privées n\'ont pas été initialisées dans vos paramètres d\'administration !',

--- a/core/lib/class.plx.date.php
+++ b/core/lib/class.plx.date.php
@@ -20,52 +20,65 @@ class plxDate {
 	 **/
 	public static function getCalendar($key, $value) {
 
-		$aMonth = array(
-			'01' => L_JANUARY,
-			'02' => L_FEBRUARY,
-			'03' => L_MARCH,
-			'04' => L_APRIL,
-			'05' => L_MAY,
-			'06' => L_JUNE,
-			'07' => L_JULY,
-			'08' => L_AUGUST,
-			'09' => L_SEPTEMBER,
-			'10' => L_OCTOBER,
-			'11' => L_NOVEMBER,
-			'12' => L_DECEMBER);
-		$aShortMonth = array(
-			'01' => L_SHORT_JANUARY,
-			'02' => L_SHORT_FEBRUARY,
-			'03' => L_SHORT_MARCH,
-			'04' => L_SHORT_APRIL,
-			'05' => L_SHORT_MAY,
-			'06' => L_SHORT_JUNE,
-			'07' => L_SHORT_JULY,
-			'08' => L_SHORT_AUGUST,
-			'09' => L_SHORT_SEPTEMBER,
-			'10' => L_SHORT_OCTOBER,
-			'11' => L_SHORT_NOVEMBER,
-			'12' => L_SHORT_DECEMBER);
-		$aDay = array(
-			'1' => L_MONDAY,
-			'2' => L_TUESDAY,
-			'3' => L_WEDNESDAY,
-			'4' => L_THURSDAY,
-			'5' => L_FRIDAY,
-			'6' => L_SATURDAY,
-			'0' => L_SUNDAY);
+		$names = array(
+			'month' => array(
+				'01' => L_JANUARY,
+				'02' => L_FEBRUARY,
+				'03' => L_MARCH,
+				'04' => L_APRIL,
+				'05' => L_MAY,
+				'06' => L_JUNE,
+				'07' => L_JULY,
+				'08' => L_AUGUST,
+				'09' => L_SEPTEMBER,
+				'10' => L_OCTOBER,
+				'11' => L_NOVEMBER,
+				'12' => L_DECEMBER
+			),
+			'short_month' => array(
+				'01' => L_SHORT_JANUARY,
+				'02' => L_SHORT_FEBRUARY,
+				'03' => L_SHORT_MARCH,
+				'04' => L_SHORT_APRIL,
+				'05' => L_SHORT_MAY,
+				'06' => L_SHORT_JUNE,
+				'07' => L_SHORT_JULY,
+				'08' => L_SHORT_AUGUST,
+				'09' => L_SHORT_SEPTEMBER,
+				'10' => L_SHORT_OCTOBER,
+				'11' => L_SHORT_NOVEMBER,
+				'12' => L_SHORT_DECEMBER
+			),
+			'long_month' => array(
+				'01' => L_LONG_JANUARY,
+				'02' => L_LONG_FEBRUARY,
+				'03' => L_LONG_MARCH,
+				'04' => L_LONG_APRIL,
+				'05' => L_LONG_MAY,
+				'06' => L_LONG_JUNE,
+				'07' => L_LONG_JULY,
+				'08' => L_LONG_AUGUST,
+				'09' => L_LONG_SEPTEMBER,
+				'10' => L_LONG_OCTOBER,
+				'11' => L_LONG_NOVEMBER,
+				'12' => L_LONG_DECEMBER
+			),
+			'day' => array(
+				'1' => L_MONDAY,
+				'2' => L_TUESDAY,
+				'3' => L_WEDNESDAY,
+				'4' => L_THURSDAY,
+				'5' => L_FRIDAY,
+				'6' => L_SATURDAY,
+				'0' => L_SUNDAY
+			)
+		);
 
-		switch ($key) {
-			case 'day':
-				$day = isset($aDay[$value]) ? $aDay[$value] : '';
-				return $day; break;
-			case 'month':
-				$month = isset($aMonth[$value]) ? $aMonth[$value] : '';
-				return $month; break;
-			case 'short_month':
-				$short_month = isset($aShortMonth[$value]) ? $aShortMonth[$value] : '';
-				return $short_month; break;
-		}
+		if(array_key_exists($key, $names) and array_key_exists($value, $names[$key]))
+			return $names[$key][$value];
+		else
+			return false;
+
 	}
 
 	/**

--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -1,5 +1,7 @@
 <?php
 
+define('ARCH_LIST_OPTION', '<option value="#archives_url" id="#archives_id" #archives_selected>#archives_name (#archives_nbart)</option>');
+
 /**
  * Classe plxShow responsable de l'affichage sur stdout
  *
@@ -1751,57 +1753,136 @@ class plxShow {
 	/**
 	 * Méthode qui affiche la liste des archives
 	 *
-	 * @param	format	format du texte pour l'affichage (variable : #archives_id, #archives_status, #archives_nbart, #archives_url, #archives_name, #archives_month, #archives_year)
+	 * @param	format	format du texte pour l'affichage (variable : #archives_id, #archives_status, #archices_selected, #archives_nbart, #archives_url, #archives_name, #archives_month, #archives_year)
 	 * @return	stdout
 	 * @scope	global
-	 * @author	Stephane F
+	 * @author	Stephane F, J.P. Pourrez
+	 * @version 2017-06-15
 	 **/
 	public function archList($format='<li id="#archives_id"><a class="#archives_status" href="#archives_url" title="#archives_name">#archives_name</a></li>'){
+		# Avec <select>, utiliser font-family: monospace; et la constante ARCH_LIST_OPTION pour la variable $format ci-dessus.
+
 		# Hook Plugins
 		if(eval($this->plxMotor->plxPlugins->callHook('plxShowArchList'))) return;
 
-		$curYear=date('Y');
-		$array = array();
-
+		# on compte le nombre d'articles pour chaque mois de la période et pour chaque année passée
 		$plxGlob_arts = clone $this->plxMotor->plxGlob_arts;
+		if($files = $plxGlob_arts->query('/^\d{4}\.(?:\d{3},|home,)*('.$this->plxMotor->activeCats.')(?:,\d{3}|,home)*\.\d{3}\.\d{12}\.[\w-]+\.xml$/','art','rsort',0,false,'before')) {
+			# compte les années en mois !
+			$periode = 12; # on détaille pour les 12 derniers mois
+			$annee_mois_cc = intval(date('Y')) * 12;
+			$ce_mois_ci = $annee_mois_cc + intval(date('n')) - 1; # on compte les mois à partir de 0
+			$premier_mois = $ce_mois_ci - $periode; # 1er mois de la période
+			$cumuls_mois = array();
+			$cumuls_ans = array();
+			$total = 0;
 
-		if($files = $plxGlob_arts->query('/^[0-9]{4}.(?:[0-9]|home|,)*(?:'.$this->plxMotor->activeCats.'|home)(?:[0-9]|home|,)*.[0-9]{3}.[0-9]{12}.[a-z0-9-]+.xml$/','art','rsort',0,false,'before')) {
+			# récupère l'année et le mois de chaque article
+			$motif = '@^\d{4}\.(?:\d{3}|home)+(?:,\d{3}|,home)*\.\d{3}\.(\d{4})(\d{2})\d{6}\.[\w-]+\.xml$@';
 			foreach($files as $id => $filename){
-				if(preg_match('/([0-9]{4}).((?:[0-9]|home|,)*(?:'.$this->plxMotor->activeCats.'|home)(?:[0-9]|home|,)*).[0-9]{3}.([0-9]{4})([0-9]{2})([0-9]{6}).([a-z0-9-]+).xml$/',$filename,$capture)){
-					if($capture[3]==$curYear) {
-						if(!isset($array[$capture[3]][$capture[4]])) $array[$capture[3]][$capture[4]]=1;
-						else $array[$capture[3]][$capture[4]]++;
-					} else {
-						if(!isset($array[$capture[3]])) $array[$capture[3]]=1;
-						else $array[$capture[3]]++;
+				if(preg_match($motif, $filename, $capture)){
+					$total++;
+					$annee = intval($capture[1]);
+					$annee_mois = $annee * 12;
+
+					# cumul pour chaque mois de la période
+					$mois = $annee_mois + intval($capture[2]) - 1; # Nb de mois depuis l'an 0
+					if($mois >= $premier_mois) {
+						# l'index de $cumuls_mois est le nombre de mois depuis l'an 0
+						if(isset($cumuls_mois[$mois]))
+							$cumuls_mois[$mois]++;
+						else
+							$cumuls_mois[$mois] = 1;
+					}
+
+					# cumul pour les années écoulées
+					if($annee_mois < $annee_mois_cc) {
+						# l'index de $cumuls_ans est l'année
+						if(isset($cumuls_ans[$annee]))
+							$cumuls_ans[$annee]++;
+						else
+							$cumuls_ans[$annee] = 1;
 					}
 				}
 			}
-			krsort($array);
-			# Affichage pour l'année en cours
-			if(isset($array[$curYear])) {
-				foreach($array[$curYear] as $month => $nbarts){
-					$name = str_replace('#archives_id','archives-'.$curYear.$month,$format);
-					$name = str_replace('#archives_name',plxDate::getCalendar('month', $month).' '.$curYear,$name);
-					$name = str_replace('#archives_year',$curYear,$name);
-					$name = str_replace('#archives_month',plxDate::getCalendar('month', $month),$name);
-					$name = str_replace('#archives_url', $this->plxMotor->urlRewrite('?archives/'.$curYear.'/'.$month), $name);
-					$name = str_replace('#archives_nbart',$nbarts,$name);
-					$name = str_replace('#archives_status',(($this->plxMotor->mode=="archives" AND $this->plxMotor->cible==$curYear.$month)?'active':'noactive'), $name);
-					echo $name;
+			krsort($cumuls_mois);
+			krsort($cumuls_ans);
+
+			$selected = (strpos($format, '#archives_selected') !== false);
+			# Affichage pour la période en cours
+			$page_actuelle = ($this->plxMotor->mode == "archives") ? $this->plxMotor->cible : '';
+			// mb_internal_encoding('utf-8');
+			$id = 0;
+			foreach($cumuls_mois as $m => $nbarts) {
+				$id++;
+				$mois = str_pad(($m % 12) + 1, 2, '0', STR_PAD_LEFT);
+				$annee = intval($m / 12);
+				$active = $page_actuelle == ''.$annee.$mois;
+				if($selected) {
+					$nom_mois = str_replace(' ', '&nbsp;', plxDate::getCalendar('long_month', $mois));
+					$nb_arts_caption = str_replace(' ', '&nbsp;', str_pad($nbarts, 4, ' ', STR_PAD_LEFT));
+				} else {
+					$nom_mois = plxDate::getCalendar('month', $mois);
+					$nb_arts_caption = $nbarts;
 				}
+				$motifs =  array(
+					'#archives_id'		=> 'arch-month-'.str_pad($id, 2, '0', STR_PAD_LEFT),
+					'#archives_name'	=> $nom_mois.' '.$annee,
+					'#archives_year'	=> $annee,
+					'#archives_month'	=> $nom_mois,
+					'#archives_url'		=> $this->plxMotor->urlRewrite('?archives/'.$annee.'/'.$mois),
+					'#archives_nbart'	=> $nb_arts_caption,
+					'#archives_status'	=> (($active) ? 'active' : 'noactive'),
+					'#archives_selected'=> (($active) ? 'selected' : '')
+				);
+				echo str_replace(array_keys($motifs), array_values($motifs), $format);
 			}
-			# Affichage pour les années précédentes
-			unset($array[$curYear]);
-			foreach($array as $year => $nbarts){
-				$name = str_replace('#archives_id','archives-'.$year,$format);
-				$name = str_replace('#archives_name',$year,$name);
-				$name = str_replace('#archives_year',$year,$name);
-				$name = str_replace('#archives_month',$year,$name);
-				$name = str_replace('#archives_url', $this->plxMotor->urlRewrite('?archives/'.$year), $name);
-				$name = str_replace('#archives_nbart',$nbarts,$name);
-				$name = str_replace('#archives_status',(($this->plxMotor->mode=="archives" AND $this->plxMotor->cible==$year)?'active':'noactive'), $name);
-				echo $name;
+
+			# Affichage annuel
+			$id = 0;
+			foreach($cumuls_ans as $annee => $nbarts){
+				$id++;
+				$active = $page_actuelle == ''.$annee;
+				if($selected) {
+					$prefix_name = str_replace(' ', '&nbsp;', L_LONG_YEAR);
+					$nb_arts_caption = str_replace(' ', '&nbsp;', str_pad($nbarts, 4, ' ', STR_PAD_LEFT));
+				} else {
+					$prefix_name = L_YEAR;
+					$nb_arts_caption = $nbarts;
+				}
+				$motifs = array(
+					'#archives_id'		=> 'arch-year-'.str_pad($id, 2, '0', STR_PAD_LEFT),
+					'#archives_name'	=> "$prefix_name $annee",
+					'#archives_year'	=> $annee,
+					'#archives_month'	=> L_YEAR,
+					'#archives_url'		=> $this->plxMotor->urlRewrite('?archives/'.$annee),
+					'#archives_nbart'	=> $nb_arts_caption,
+					'#archives_status'	=> ($active) ? 'active' : 'noactive',
+					'#archives_selected'=> ($active) ? 'selected' : ''
+				);
+				echo str_replace(array_keys($motifs), array_values($motifs), $format);
+			}
+
+			# Total des articles
+			if(strpos($format, '#archives_nbart') !== false) {
+				if($selected) {
+					$prefix_name = str_replace(' ', '&nbsp;', L_LONG_TOTAL.'     ');
+					$nb_arts_caption = str_replace(' ', '&nbsp;', str_pad($total, 4, ' ', STR_PAD_LEFT));
+				} else {
+					$prefix_name = L_TOTAL;
+					$nb_arts_caption = $total;
+				}
+				$motifs = array(
+					'#archives_id'		=> 'arch-total',
+					'#archives_name'	=> $prefix_name.' ',
+					'#archives_year'	=> str_repeat('–', 4),
+					'#archives_month'	=> L_TOTAL,
+					'#archives_url'		=> $this->plxMotor->urlRewrite(),
+					'#archives_nbart'	=> $nb_arts_caption,
+					'#archives_status'	=> ($active) ? 'active' : 'noactive',
+					'#archives_selected'=> ($active) ? 'selected' : ''
+				);
+				echo str_replace(array_keys($motifs), array_values($motifs), $format);
 			}
 		}
 	}


### PR DESCRIPTION
- ajout de #archives_select pour preselectionner une option dans &lt;select&gt;
- cumul mensuel sur une période gilissante de 12 mois et non à partir du 1er janvier
- alignement parfait des mois, année et nombre articles dans les options d'un select (police monospace obligatoire)
- grosse optimisation du code pour réduire le nombre d'appels à str_replace

voir discussion ici http://forum.pluxml.org/viewtopic.php?id=5995