### PR TITLE
Drag&Drop 4 old Browser & 4 order of active plugins

### DIFF
--- a/core/admin/categories.php
+++ b/core/admin/categories.php
@@ -70,7 +70,7 @@ include(dirname(__FILE__).'/top.php');
 			if($plxAdmin->aCats) {
 				foreach($plxAdmin->aCats as $k=>$v) { # Pour chaque catégorie
 					$ordre = ++$num;
-					echo '<tr draggable="true" ondragend="DragDrop.dragend(event, \'categories-table\')" ondragenter="DragDrop.dragenter(event)" ondragstart="DragDrop.dragstart(event)">';
+					echo '<tr draggable="true" ondragover="event.preventDefault()" ondragend="DragDrop.dragend(event, \'categories-table\')" ondragenter="DragDrop.dragenter(event)" ondragstart="DragDrop.dragstart(event)">';
 					echo '<td class="tb-drag-icon"><input type="checkbox" name="idCategory[]" value="'.$k.'" /><input type="hidden" name="catNum[]" value="'.$k.'" /></td>';
 					echo '<td>'.$k.'</td><td>';
 					plxUtils::printInput($k.'_name', plxUtils::strCheck($v['name']), 'text', '-50');

--- a/core/admin/parametres_plugins.php
+++ b/core/admin/parametres_plugins.php
@@ -41,10 +41,10 @@ function pluginsList($plugins, $defaultLang, $type) {
 			else
 			$icon=PLX_CORE.'admin/theme/images/icon_plugin.png';
 
-			$output .= '<tr class="top">';
+			$output .= '<tr class="top"'.($type?' draggable="true" ondragover="event.preventDefault()" ondragend="DragDrop.dragend(event, \'plugins-table\')" ondragenter="DragDrop.dragenter(event)" ondragstart="DragDrop.dragstart(event)"':'').'>';
 
 				# checkbox
-				$output .= '<td>';
+				$output .= '<td'.($type?' class="tb-drag-icon"':'').'>';
 				$output .= '<input type="hidden" name="plugName[]" value="'.$plugName.'" />';
 				$output .= '<input type="checkbox" name="chkAction[]" value="'.$plugName.'" />';
 				$output .= '</td>';
@@ -150,7 +150,7 @@ include(dirname(__FILE__).'/top.php');
 					<th>&nbsp;</th>
 					<th><input type="text" id="plugins-search" onkeyup="plugFilter()" placeholder="<?php echo L_SEARCH ?>..." title="<?php echo L_SEARCH ?>" /></th>
 					<?php if($_SESSION['selPlugins']=='1') : ?>
-					<th><?php echo L_PLUGINS_LOADING_SORT ?></th>
+					<th data-id="order"><?php echo L_PLUGINS_LOADING_SORT ?></th>
 					<?php endif; ?>
 					<th><?php echo L_PLUGINS_ACTION ?></th>
 				</tr>

--- a/core/admin/statiques.php
+++ b/core/admin/statiques.php
@@ -81,7 +81,7 @@ function checkBox(cb) {
 			if($plxAdmin->aStats) {
 				foreach($plxAdmin->aStats as $k=>$v) { # Pour chaque page statique
 					$ordre = ++$num;
-					echo '<tr draggable="true" ondragend="DragDrop.dragend(event, \'statics-table\')" ondragenter="DragDrop.dragenter(event)" ondragstart="DragDrop.dragstart(event)">';
+					echo '<tr draggable="true" ondragover="event.preventDefault()" ondragend="DragDrop.dragend(event, \'statics-table\')" ondragenter="DragDrop.dragenter(event)" ondragstart="DragDrop.dragstart(event)">';
 					echo '<td class="tb-drag-icon"><input type="checkbox" name="idStatic[]" value="'.$k.'" /><input type="hidden" name="staticNum[]" value="'.$k.'" /></td>';
 					echo '<td>'.$k.'</td><td>';
 					$selected = $plxAdmin->aConf['homestatic']==$k ? ' checked="checked"' : '';

--- a/core/lib/visual.js
+++ b/core/lib/visual.js
@@ -105,13 +105,15 @@ var DragDrop = {
 	dragstart: function(e) {
 		this.source = e.target;
 		e.dataTransfer.effectAllowed = 'move';
+		e.dataTransfer.setData('clipBoard', e.target);//old Browser
 	},
 	dragend: function(e,tb) {
 		e.preventDefault();
 		var numcol = document.querySelectorAll('#'+tb+' thead th[data-id="order"]')[0].cellIndex;
 		var rows = document.querySelectorAll('#'+tb+' tbody tr');
-		for(var i=0;i<rows.length-1;i++) {
-			rows[i].cells[numcol].getElementsByTagName('input')[0].value = i+1;
+		for(var i=0;i<rows.length;i++) {
+			if(rows[i].cells[numcol].getElementsByTagName('input')[0])
+				rows[i].cells[numcol].getElementsByTagName('input')[0].value = i+1;
 		}
 	}
 }


### PR DESCRIPTION
Le Glissé Déposé est impossible avec un vieux Firefox 43, c'est chose réglée.
Et j'me suis dit qu'il serait bien aussi d'ajouter cette possibilité aux Plugins actifs :-)
Ayant bossé sur ma branche maître et pour t’éviter un mal de tête, j'ai créé cette branche avec les ajouts nécessaires qui vont bien.

Ci-dessous le résumé des modifs de la [branche D&D (en uf8)](https://github.com/sudwebdesign/PluXml/tree/D%26D)
[Fix Drag & Drop in old Browser](https://github.com/sudwebdesign/PluXml/commit/774d0bb8fa1d6d1496cf843201fb1d959b3ba408)
[Drag & Drop more user friendly](https://github.com/sudwebdesign/PluXml/commit/74c04e2f5f44f509e6015ec48af81c56fd87cb60)
[Tri ordre de chargement des plugins actifs par drag&drop](https://github.com/sudwebdesign/PluXml/commit/3c7895d09b5084196bc5ba8b694930cf897c9177)
[Fix: ordre du dernier plugin non mis a jour](https://github.com/sudwebdesign/PluXml/commit/4776be44274b9c4ed6818133a04978362f422124)
[Fix: ordre dernier element input inexistant Stat & cat, only4New](https://github.com/sudwebdesign/PluXml/commit/2e2e5d3fe9adb2fd8330e80dff6c98ed56e4b5e5)