### PR TITLE
Paramètrage par défaut articles/page pour les catégories laissé à blanc

### DIFF
--- a/core/admin/categories.php
+++ b/core/admin/categories.php
@@ -112,7 +112,7 @@ include(dirname(__FILE__).'/top.php');
 						echo '</td><td>';
 						plxUtils::printSelect($new_catid.'_tri', $aTri, $plxAdmin->aConf['tri']);
 						echo '</td><td>';
-						plxUtils::printInput($new_catid.'_bypage', $plxAdmin->aConf['bypage'], 'text', '-3');
+						plxUtils::printInput($new_catid.'_bypage', '', 'text', '-3');
 						echo '</td><td>';
 						plxUtils::printInput($new_catid.'_ordre', ++$num, 'text', '-3');
 						echo '</td><td>';

--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -481,7 +481,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 					$this->aCats[$cat_id]['name'] = $cat_name;
 					$this->aCats[$cat_id]['url'] = $cat_url;
 					$this->aCats[$cat_id]['tri'] = $content[$cat_id.'_tri'];
-					$this->aCats[$cat_id]['bypage'] = intval($content[$cat_id.'_bypage']);
+					$this->aCats[$cat_id]['bypage'] = !empty($content[$cat_id.'_bypage']) ? intval($content[$cat_id.'_bypage']) : '';
 					$this->aCats[$cat_id]['menu'] = $content[$cat_id.'_menu'];
 					$this->aCats[$cat_id]['active'] = $content[$cat_id.'_active'];
 					$this->aCats[$cat_id]['ordre'] = intval($content[$cat_id.'_ordre']);

--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -176,7 +176,7 @@ class plxMotor {
 				$this->motif = '/^[0-9]{4}.(?:[0-9]|home|,)*(?:'.$this->cible.')(?:[0-9]|home|,)*.[0-9]{3}.[0-9]{12}.[a-z0-9-]+.xml$/'; # Motif de recherche
 				$this->template = $this->aCats[$this->cible]['template'];
 				$this->tri = $this->aCats[$this->cible]['tri']; # Recuperation du tri des articles
-				$this->bypage = $this->aCats[$this->cible]['bypage'] > 0 ? $this->aCats[$this->cible]['bypage'] : $this->bypage;
+				$this->bypage = !empty($this->aCats[$this->cible]['bypage']) ? $this->aCats[$this->cible]['bypage'] : $this->bypage;
 			}
 			elseif(isset($this->aCats[$this->cible])) { # Redirection 301
 				if($this->aCats[$this->cible]['url']!=$capture[2]) {


### PR DESCRIPTION
Lorsque le paramétrage général pour le nombre d'articles/page est modifié, il n'y a aucune répercussion pour les catégories car on enregistre toujours ce paramétrage par défaut pour chaque catégorie au lieu de laisser vide le champ de saisie.

ce PR corrige le problème.
Pour chaque catégorie on peut soit fixer le nombre d'articles/page, soit laisser ce choix au paramètrage général. Ainsi toute modif au niveau général sera repercuté si on a pas donné de valeur