### PR TITLE
Test si maj PluXml dispo (cas allow_url_fopen = false)

### DIFF
--- a/core/admin/parametres_infos.php
+++ b/core/admin/parametres_infos.php
@@ -19,7 +19,7 @@ include(dirname(__FILE__).'/top.php');
 <div class="inline-form action-bar">
 	<h2><?php echo L_CONFIG_INFOS_TITLE ?></h2>
 	<p><strong><?php echo L_PLUXML_CHECK_VERSION ?></strong></p>
-	<p><span class="text-red"><?php echo $plxAdmin->checkMaj(); ?></span></p>
+	<p><?php echo $plxAdmin->checkMaj(); ?></p>
 </div>
 
 <p><?php echo L_CONFIG_INFOS_DESCRIPTION ?></p>
@@ -50,6 +50,66 @@ include(dirname(__FILE__).'/top.php');
 <p><?php echo L_CONFIG_INFOS_WRITER ?> <?php echo $plxAdmin->aUsers[$_SESSION['user']]['name'] ?></p>
 
 <?php eval($plxAdmin->plxPlugins->callHook('AdminSettingsInfos')) ?>
+<script type="text/javascript">
+function check_maj(response) {
+	'use strict';
+
+	const node = document.querySelector('span.latest-version.error[data-update]');
+	const data = JSON.parse(node.getAttribute('data-update'));
+	const version = data.version;
+	var release;
+	if(typeof response === 'string') {
+		release = response;
+	} else if(typeof response === 'object' && typeof response.data.tag_name !== 'undefined') {
+		/* https://developer.github.com/v3/repos/releases/#get-the-latest-release */
+		release = response.data.tag_name;
+	} else {
+		return;
+	}
+
+	function compareVersion(v1, v2) {
+	    var v1parts = v1.split('.'), v2parts = v2.split('.');
+	    var maxLen = Math.max(v1parts.length, v2parts.length);
+	    var result = 0;
+	    for(var i = 0; i < maxLen; i++) {
+	        var part1 = parseInt(v1parts[i], 10) || 0;
+	        var part2 = parseInt(v2parts[i], 10) || 0;
+	        if(part1 > part2) {
+	            result = 1;
+	            break;
+			} else if(part1 < part2) {
+	            return -1;
+	            break;
+			}
+	    }
+	    return result;
+	}
+
+	node.classList.remove('error');
+	if(compareVersion(release, version) > 0) {
+		node.innerHTML = data.available;
+		node.classList.add('blink');
+	} else {
+		node.textContent = data.uptodate;
+		node.classList.add('success');
+	}
+}
+
+(function() {
+	'use strict';
+
+	const node = document.querySelector('span.latest-version.error[data-update]');
+	if(node != null) {
+		/* https://developer.github.com/v3/#json-p-callbacks */
+		const URL = 'https://api.github.com/repos/pluxml/PluXml/releases/latest';
+		// const URL = 'http://kazimentou.fr/divers/PluXml-download';
+		const script = document.createElement('SCRIPT');
+		script.type = 'text/javascript';
+		script.src = URL + '?callback=check_maj';
+		document.head.appendChild(script);
+	}
+})();
+</script>
 <?php
 # On inclut le footer
 include(dirname(__FILE__).'/foot.php');

--- a/core/admin/theme/theme.css
+++ b/core/admin/theme/theme.css
@@ -830,3 +830,29 @@ body.mediasManager .section .action-bar {
 	}
 
 }
+/* ----- latest version ------ */
+@-webkit-keyframes latest-version-blink {
+  50% { background-color: #fff; }
+}
+@keyframes latest-version-blink {
+  50% { background-color: #fff; }
+}
+.latest-version {
+	background-color: #fff;
+	border: none;
+	margin: 0;
+	margin-left: -0.8rem;
+	padding: 0 0.8rem;
+	font-size: initial;
+}
+.latest-version.success  {
+	color: green;
+}
+.latest-version.error  {
+	color: red;
+}
+.latest-version.blink {
+	color: red;
+	-webkit-animation: latest-version-blink 1s steps(1) infinite;
+	animation: latest-version-blink 1s steps(1) infinite;
+}

--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -1055,30 +1055,64 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 	}
 
 	/**
-	 * Méthode qui vérifie sur le site de PluXml la dernière version et la compare avec celle en local
+	 * Méthode qui vérifie sur le site de PluXml la dernière version et la compare avec celle en local.
 	 *
-	 * @return	string	message contenant l'etat du control du numéro de version
-	 * @author	Florent MONTHEL, Amaury GRAILLAT et Stephane F
+	 * @param	url		adresse pour connaitre la dernière release
+	 * @param	href	lien vers page accueil
+	 * @param	caption titre à afficher
+	 * @return	string	contenu innerHTML de la balise <p> contenant l'etat et le style du contrôle du numéro de version
+	 * @author	Florent MONTHEL, Amaury GRAILLAT, Stephane F et J.P. Pourrez (aka bazooka07)
 	 **/
-	public function checkMaj() {
+	public function checkMaj($url='http://telechargements.pluxml.org/latest-version', $href='http://www.pluxml.org/', $caption='PluXml.org') {
 
-		# La fonction est active ?
-		if(!ini_get('allow_url_fopen')) return L_PLUXML_UPDATE_UNAVAILABLE;
-				$latest_version = '';
-
-		# Requete HTTP sur le site de PluXml
-		if($fp = @fopen('http://telechargements.pluxml.org/latest-version', 'r')) {
-					$latest_version = trim(fread($fp, 16));
-					fclose($fp);
+		$latest_version = false;
+		$msg = L_PLUXML_UPDATE_UNAVAILABLE;
+		$className = false;
+		$available = L_PLUXML_UPDATE_AVAILABLE;
+	 	$available .= <<< EOT
+ <a href="$href">$caption</a>
+EOT;
+		# Urls autorisés dans allow_url_open ou file_get_contents ?
+		if(ini_get('allow_url_fopen')) {
+			# Requete HTTP sur le site de PluXml
+			$msg = L_PLUXML_UPDATE_ERR;
+			$latest_version = @file_get_contents($url, false, null, 0, 16);
+			if(
+				!empty($http_response_header) and
+				preg_match('@^HTTP/[\d\.]+ 200@', $http_response_header[0]) and
+				!empty($latest_version)
+			) {
+				# Comparaison avec la dernière version officielle
+				if(version_compare(PLX_VERSION, $latest_version, ">=")) {
+					$msg = L_PLUXML_UPTODATE.' ('.PLX_VERSION.')';
+					$className = 'success';
 				}
-		if($latest_version == '')
-			return L_PLUXML_UPDATE_ERR;
+				else {
+				 	$msg = $available;
+				 	$className = 'blink';
+				}
+			}
+		}
+		if(empty($className)) {
+			$className = 'error';
+			$data = ' data-update=\''.
+				json_encode(
+					array(
+						'available'		=> $available,
+						'uptodate'		=> L_PLUXML_UPTODATE,
+						'version'		=> PLX_VERSION
+					),
+					JSON_UNESCAPED_UNICODE
+				).
+				'\'';
+		} else {
+			$data = '';
+		}
+		return <<< MSG
+	<span class="latest-version $className"$data>$msg</span>
 
-		# Comparaison
-		if(version_compare(PLX_VERSION, $latest_version, ">="))
-			return L_PLUXML_UPTODATE.' ('.PLX_VERSION.')';
-		else
-		 	return L_PLUXML_UPDATE_AVAILABLE.' <a href="http://www.pluxml.org/">PluXml.org</a>';
+MSG;
+
 	}
 
 }


### PR DESCRIPTION
plxAmin::checkMaj accepte maintenant les paramètres $url, $href, $caption.

En cas d'échec, on utilise Javascript sur le navigateur et on interroge Github
ou un autre serveur avec le protocole JSON-P.

Remplace le précèdent PR check_maj2 ( mauvaise manip sur Github)