### PR TITLE
Suppression regles CSS obsoletes pour le tri des rangees de tableaux

### DIFF
--- a/core/admin/theme/theme.css
+++ b/core/admin/theme/theme.css
@@ -780,21 +780,6 @@ div.ico div {
 	cursor: pointer;
 }
 
-/* Drag & Drop Table */
-
-.tb-drag-icon {
-	background-image: url(images/tb-drag-icon.gif);
-	background-repeat: repeat-y;
-	cursor: move;
-}
-
-#categories-table th:nth-child(1),
-#categories-table td:nth-child(1),
-#statics-table th:nth-child(1),
-#statics-table td:nth-child(1) {
-	padding-left: 12px;
-}
-
 /* ------- MEDIASMANAGER ------ */
 
 body.mediasManager .aside {


### PR DESCRIPTION
Mon pull-request ne fait aucune référence aux tables #categories-table et #statics-table pour trier les rangées des tableaux avec la souris.