### PR TITLE
Sélection des plugins à charger selon côté admin ou côté site

### DIFF
--- a/core/admin/parametres_plugin.php
+++ b/core/admin/parametres_plugin.php
@@ -19,7 +19,7 @@ $output='';
 $filename = realpath(PLX_PLUGINS.$plugin.'/config.php');
 if(is_file($filename)) {
 	# si le plugin n'est pas actif, aucune instance n'a été créée, on va donc la créer, sinon on prend celle qui existe
-	if(!isset($plxAdmin->plxPlugins->aPlugins[$plugin]))
+	if(empty($plxAdmin->plxPlugins->aPlugins[$plugin]))
 		$plxPlugin = $plxAdmin->plxPlugins->getInstance($plugin);
 	else
 		$plxPlugin = $plxAdmin->plxPlugins->aPlugins[$plugin];

--- a/core/admin/parametres_plugins.php
+++ b/core/admin/parametres_plugins.php
@@ -41,7 +41,11 @@ function pluginsList($plugins, $defaultLang, $type) {
 			else
 			$icon=PLX_CORE.'admin/theme/images/icon_plugin.png';
 
-			$output .= '<tr class="top">';
+			# plugin activé uniquement côté site (<usage> == 'site')
+			if(empty($plugInstance) and $plugInstance=plxPlugins::getInstance($plugName)) {
+				$plugInstance->getInfos();
+			}
+			$output .= '<tr class="top" data-usage="'.$plugInstance->getInfo('usage').'">';
 
 				# checkbox
 				$output .= '<td>';
@@ -163,8 +167,11 @@ include(dirname(__FILE__).'/top.php');
 		</table>
 	</div>
 
-	<?php if($_SESSION['selPlugins']=='1') : ?>
-	<?php endif; ?>
+	<div id="plugins-usage" class="in-action-bar">
+		<div><strong data-usage=""><?php echo L_GENERAL_PURPOSE; ?></strong></div>
+		<div><strong data-usage="admin">Admin</strong></div>
+		<div><strong data-usage="site">Site</strong></div>
+	</div>
 
 </form>
 

--- a/core/admin/plugin.php
+++ b/core/admin/plugin.php
@@ -14,7 +14,7 @@ $plugin = plxUtils::nullbyteRemove($plugin);
 $output='';
 # chargement du fichier d'administration du plugin
 $filename = realpath(PLX_PLUGINS.$plugin.'/admin.php');
-if(isset($plxAdmin->plxPlugins->aPlugins[$plugin]) AND is_file($filename)) {
+if(!empty($plxAdmin->plxPlugins->aPlugins[$plugin]) AND is_file($filename)) {
 	# utilisation de la variable plxPlugin pour faciliter la syntaxe dans les devs des plugins
 	$plxPlugin = $plxAdmin->plxPlugins->aPlugins[$plugin];
 	# Control des autorisation d'accès à l'écran admin.php du plugin

--- a/core/admin/theme/theme.css
+++ b/core/admin/theme/theme.css
@@ -855,3 +855,28 @@ select {
 select {
 	padding: 0 18px 0 0;
 }
+/* ---- parametres_plugins ---- */
+#plugins-table tbody tr[data-usage] td.wrap strong:first-of-type {
+    padding: 0.2rem 0.5rem;
+}
+#plugins-table tbody tr[data-usage="admin"] td.wrap strong:first-of-type,
+#plugins-usage.in-action-bar strong[data-usage="admin"] {
+    background-color: red;
+    color: #fff;
+}
+#plugins-table tbody tr[data-usage="site"] td.wrap strong:first-of-type,
+#plugins-usage.in-action-bar strong[data-usage="site"] {
+    background-color: green;
+    color: #fff;
+}
+#plugins-usage.in-action-bar {
+    right: 1.5rem;
+    width: 15rem;
+    margin-top: 1rem;
+}
+#plugins-usage.in-action-bar strong {
+	display: inline-block;
+	width: 100%;
+	margin: 0.3rem 0;
+	text-align: center;
+}

--- a/core/lang/de/admin.php
+++ b/core/lang/de/admin.php
@@ -377,6 +377,7 @@ $LANG = array(
 'L_PLUGINS_CSS_TITLE'								=> 'Bearbeiten Sie den CSS-Code des Plugins',
 'L_CONTENT_FIELD_FRONTEND'							=> 'CSS-Datei-Inhalte Website',
 'L_CONTENT_FIELD_BACKEND'							=> 'CSS-Datei Content-Administrator',
+'L_GENERAL_PURPOSE'									=> 'Allgemeiner Zweck',
 'L_PLUGINS_TITLE'									=> 'Pluginverwaltung',
 'L_PLUGINS_VERSION'									=> 'Version',
 'L_PLUGINS_AUTHOR'									=> 'Autor',

--- a/core/lang/en/admin.php
+++ b/core/lang/en/admin.php
@@ -376,6 +376,7 @@ $LANG = array(
 'L_PLUGINS_CSS_TITLE'										=> 'Edit the css code of the plugin',
 'L_CONTENT_FIELD_FRONTEND'									=> 'Css file content site',
 'L_CONTENT_FIELD_BACKEND'									=> 'Css file content administrator',
+'L_GENERAL_PURPOSE'											=> 'General purpose',
 'L_PLUGINS_TITLE'											=> 'Manage plugins',
 'L_PLUGINS_VERSION'											=> 'Version',
 'L_PLUGINS_AUTHOR'											=> 'Author',

--- a/core/lang/es/admin.php
+++ b/core/lang/es/admin.php
@@ -439,6 +439,7 @@ $LANG = array(
 'L_PLUGINS_CSS_TITLE'							=> 'Editar el código CSS del complemento',
 'L_CONTENT_FIELD_FRONTEND'						=> 'Contenido del archivo de código CSS para el sitio web',
 'L_CONTENT_FIELD_BACKEND'						=> 'Contenido del archivo de código CSS para el sitio de administración',
+'L_GENERAL_PURPOSE'								=> 'multiuso',
 
 # parametres_plugins.php
 

--- a/core/lang/fr/admin.php
+++ b/core/lang/fr/admin.php
@@ -443,6 +443,7 @@ $LANG = array(
 'L_PLUGINS_CSS_TITLE'				=> 'Éditer le code CSS du plugin',
 'L_CONTENT_FIELD_FRONTEND'			=> 'Contenu fichier CSS site',
 'L_CONTENT_FIELD_BACKEND'			=> 'Contenu fichier CSS administrateur',
+'L_GENERAL_PURPOSE'					=> 'Tous usages',
 
 # parametres_plugins.php
 

--- a/core/lang/it/admin.php
+++ b/core/lang/it/admin.php
@@ -376,6 +376,7 @@ $LANG = array(
 'L_PLUGINS_CSS_TITLE'										=> 'Modificare il codice css del plugin',
 'L_CONTENT_FIELD_FRONTEND'									=> 'Sito web contenuto del file Css',
 'L_CONTENT_FIELD_BACKEND'									=> 'Amministratore contenuti css',
+'L_GENERAL_PURPOSE'											=> 'tutto l\'uso',
 'L_PLUGINS_TITLE'											=> 'Gestione plugin',
 'L_PLUGINS_VERSION'											=> 'Versione',
 'L_PLUGINS_AUTHOR'											=> 'Autore',


### PR DESCRIPTION
Voir fil de discussion  http://forum.pluxml.org/viewtopic.php?id=6159

Prise en compte de la balise &lt;usage&gt; dans les fichiers infos.xml des plugins pour charger uniquement les plugins activés nécessaires soit côté admin, soit côté site.
La balise peut prendre les valeurs admin, site, ou être vide ou absente (rétro-compatilité.
A la mise à jour, enregistrer la liste des plugins activés pour prendre en compte la nouvelle balise.
Côté site, on peut voir la liste des plugins réellement chargés en ajoutant la ligne suivante à la fin du fichier footer.php du thème courant :
`<?php echo "<!--\n\$plugins = array(\n\t'".implode("',\n\t'", array_keys($plxShow->plxMotor->plxPlugins->aPlugins))."'\n);\n-->\n"; ?>`
copies d'écran
https://flic.kr/p/HDQA8c
https://flic.kr/p/21fErAF
