### PR TITLE
tag status noactive par défaut

### DIFF
--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -1763,7 +1763,7 @@ class plxShow {
 			$id=0;
 			foreach($counters as $tag => $counter) {
 				$url = plxUtils::title2url($tag);
-				$status = '';
+				$status = 'noactive';
 				switch($mode) {
 					case 'article':
 						if(in_array($tag, $artTags)) {


### PR DESCRIPTION
Lorsque l'on est ni dans une page article, ni dans une page de tags, le $status "noactive" n'était pas renvoyé.