### PR TITLE
Justify text in a paragraph in the default theme

### DIFF
--- a/themes/defaut/css/theme.css
+++ b/themes/defaut/css/theme.css
@@ -237,6 +237,11 @@ a.active {
 
 /* ------- Article ------- */
 
+.article p {
+        text-align: justify;
+        text-justify: inter-word;	
+}
+
 .article header {
 	margin-top: 2rem;
 }


### PR DESCRIPTION
Text in an article paragraph is not justified in the default theme. I think it is easier to read and most clear to have it justified.