### PR TITLE
Suppression des simples et doubles strophes

### DIFF
--- a/core/admin/parametres_help.php
+++ b/core/admin/parametres_help.php
@@ -44,7 +44,7 @@ if(is_file($filename)) {
 		<h2>'.plxUtils::strCheck($page).'</h2>
 		<p><a class="back" href="'.$back_to.'">'.$back_to_title.'</a></p>
 	</div>';
-	include "$filename";
+	include $filename;
 	$output=ob_get_clean();
 }
 else {

--- a/core/admin/parametres_plugin.php
+++ b/core/admin/parametres_plugin.php
@@ -33,7 +33,7 @@ if(is_file($filename)) {
 		<h2>'.plxUtils::strCheck($plugin).'</h2>
 		<p><a class="back" href="parametres_plugins.php">'.L_BACK_TO_PLUGINS.'</a></p>
 	</div>';
-	include "$filename";
+	include $filename;
 	$output=ob_get_clean();
 }
 else {

--- a/core/admin/plugin.php
+++ b/core/admin/plugin.php
@@ -24,7 +24,7 @@ if(!empty($plxAdmin->plxPlugins->aPlugins[$plugin]) AND is_file($filename)) {
 	<div class="inline-form action-bar">
 		<h2>'.plxUtils::strCheck($plugin).'</h2>
 	</div>';
-	include "$filename";
+	include $filename;
 	$output=ob_get_clean();
 }
 else {

--- a/core/lib/class.plx.plugins.php
+++ b/core/lib/class.plx.plugins.php
@@ -33,7 +33,7 @@ class plxPlugins {
 	public function getInstance($plugName) {
 		$filename = PLX_PLUGINS."$plugName/$plugName.php";
 		if(is_file($filename)) {
-			include_once "$filename";
+			include_once $filename;
 			if (class_exists($plugName)) {
 				# réactualisation de la langue si elle a été modifié par un plugin
 				$context = defined('PLX_ADMIN') ? 'admin_lang' : 'lang';
@@ -489,7 +489,7 @@ class plxPlugin {
 	 **/
 	public function loadLang($filename) {
 		if(!is_file($filename)) return;
-		include '$filename';
+		include $filename;
 		return $LANG;
 	}
 

--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -39,7 +39,7 @@ class plxShow {
 		# Chargement du fichier de lang du theme
 		$langfile = PLX_ROOT.$this->plxMotor->aConf['racine_themes'].$this->plxMotor->style.'/lang/'.$this->plxMotor->aConf['default_lang'].'.php';
 		if(is_file($langfile)) {
-			include "$langfile";
+			include $langfile;
 			$this->lang = $LANG; # $LANG = tableau contenant les traductions présentes dans le fichier de langue
 		}
 

--- a/core/lib/config.php
+++ b/core/lib/config.php
@@ -58,7 +58,7 @@ if (ini_get('register_globals')) {
 function loadLang($filename) {
 	if(file_exists($filename)) {
 		$LANG = array();
-		include_once "$filename";
+		include_once $filename;
 		foreach($LANG as $key => $value) {
 			if(!defined($key)) define($key,$value);
 		}


### PR DESCRIPTION
encadrant uniquement les noms de variables dans mes directives
include et include_once.

Pour vérifier, faire :
> grep include core/{admin,lib}/*.php