### PR TITLE
Génére le fichier robots.txt à la racine du site.

### DIFF
--- a/core/admin/parametres_avances.php
+++ b/core/admin/parametres_avances.php
@@ -54,6 +54,21 @@ include __DIR__ .'/top.php';
 			</div>
 		</div>
 		<div class="grid">
+			<div class="col sml-12 med-5">
+				<label for="id_robots">
+<?php
+	echo L_CONFIG_ADVANCED_ROBOTS_TXT;
+	if(!file_exists($_SERVER['DOCUMENT_ROOT'].'/robots.txt')) {
+		echo '&nbsp;<span style="margin-top:5px" class="alert red float-right">'.L_CONFIG_ADVANCED_ROBOTS_TXT_MISSING.'</span>';
+	}
+?>&nbsp;:
+				</label>
+			</div>
+			<div class="col sml-12 med-7">
+<?php plxUtils::printSelect('robots',array('1'=>L_YES,'0'=>L_NO), (array_key_exists('robots', $plxAdmin->aConf)) ? $plxAdmin->aConf['robots'] : '1'); ?>
+			</div>
+		</div>
+		<div class="grid">
 			<div class="col sml-12 med-5 label-centered">
 				<label for="id_gzip"><?php echo L_CONFIG_ADVANCED_GZIP ?>&nbsp;:</label>
 			</div>

--- a/core/admin/parametres_infos.php
+++ b/core/admin/parametres_infos.php
@@ -49,6 +49,17 @@ include __DIR__ .'/top.php';
 <p><?php echo L_CONFIG_INFOS_NB_CATS ?> <?php echo sizeof($plxAdmin->aCats); ?></p>
 <p><?php echo L_CONFIG_INFOS_NB_STATICS ?> <?php echo sizeof($plxAdmin->aStats); ?></p>
 <p><?php echo L_CONFIG_INFOS_WRITER ?> <?php echo $plxAdmin->aUsers[$_SESSION['user']]['name'] ?></p>
+<?php
+$filename = $_SERVER['DOCUMENT_ROOT'] .'/robots.txt';
+if(file_exists($filename)) {
+?>
+<p><?php echo L_CONFIG_INFOS_ROBOTS_TXT; ?></p>
+<pre><code>
+<?php readfile($filename); ?>
+</code></pre>
+<?php
+}
+?>
 
 <?php eval($plxAdmin->plxPlugins->callHook('AdminSettingsInfos')) ?>
 

--- a/core/lang/en/admin.php
+++ b/core/lang/en/admin.php
@@ -494,5 +494,8 @@ $LANG = array(
 'L_CONFIG_THEME_UPDATE'										=> 'Change Theme',
 'L_ERR_INVALID_DATE_CREATION'								=> 'Invalid creation date',
 'L_ERR_INVALID_DATE_UPDATE'									=> 'Invalid date updated',
+'L_CONFIG_ADVANCED_ROBOTS_TXT_MISSING'						=> 'missing',
+'L_CONFIG_ADVANCED_ROBOTS_TXT'								=> 'Setup "robots.txt" file',
+'L_CONFIG_INFOS_ROBOTS_TXT'									=> 'Dump of "robots.txt" file',
 );
 ?>

--- a/core/lang/fr/admin.php
+++ b/core/lang/fr/admin.php
@@ -369,6 +369,8 @@ $LANG = array(
 
 'L_CONFIG_ADVANCED_DESC'			=> 'Configuration avancée',
 'L_CONFIG_ADVANCED_URL_REWRITE'		=> 'Activer la réécriture d\'URL',
+'L_CONFIG_ADVANCED_ROBOTS_TXT'		=> 'Gérer le fichier robots.txt',
+'L_CONFIG_ADVANCED_ROBOTS_TXT_MISSING' => 'absent',
 'L_CONFIG_ADVANCED_URL_REWRITE_ALERT'=> 'Attention un fichier .htaccess est déjà présent à la racine de votre PluXml. En activant la réécriture d\'url ce fichier sera modifié',
 'L_CONFIG_ADVANCED_GZIP'			=> 'Activer la compression GZIP',
 'L_CONFIG_ADVANCED_GZIP_HELP'		=> 'Permet de compresser les pages pour économiser de la bande passante, cependant cela peut augmenter la charge processeur',
@@ -421,6 +423,7 @@ $LANG = array(
 'L_PLUXML_UPDATE_ERR'				=> 'La vérification de mise à jour a échoué pour une raison inconnue',
 'L_PLUXML_UPTODATE'					=> 'Vous utilisez la dernière version de PluXml',
 'L_PLUXML_UPDATE_AVAILABLE'			=> 'Une nouvelle version de PluXml est sortie ! Vous pouvez la télécharger sur',
+'L_CONFIG_INFOS_ROBOTS_TXT'			=> 'Contenu du fichier "robots.txt" :',
 
 # parametres_users.php
 


### PR DESCRIPTION
Il n'est pas nécessaire que PluXml soit installé à la racine du site.