### PR TITLE
Check maj 200110

### DIFF
--- a/core/admin/parametres_infos.php
+++ b/core/admin/parametres_infos.php
@@ -31,7 +31,7 @@ if($emailBuild) {
 <div class="inline-form action-bar">
 	<h2><?php echo L_CONFIG_INFOS_TITLE ?></h2>
 	<p><?php echo L_PLUXML_CHECK_VERSION ?></p>
-	<?php echo $plxAdmin->checkMaj(); ?>
+	<?php $maj = $plxAdmin->checkMaj(); echo $maj; ?>
 </div>
 
 <p><?php echo L_CONFIG_INFOS_DESCRIPTION ?></p>
@@ -114,7 +114,58 @@ HEAD;
 	header('Location: ' . basename(__FILE__));
 	exit;
 }
+if(preg_match('%class="[^"]*\bred\b[^"]*"%', $maj)) {
+	# checkMaj() has failed with curl or allow_url_fopen is off
+?>
+	<script type="text/javascript">
+		(function() {
+			'use strict';
+			const currentVersion = '<?= PLX_VERSION ?>';
+			const id = 'latest-version';
+			const el = document.getElementById(id);
+			if(el == null) {
+				console.error('Element with id="' + id + '" not found');
+				return;
+			}
 
+			function compareVersion(v1, v2) {
+				if(typeof v1 != 'string' || typeof v2 != 'string') { return; }
+
+				const t1 = v1.split('.');
+				const t2 = v2.split('.');
+				for(let i=0, iMax=(t1.length < t2.length) ? t1.length : t2.length; i<iMax; i++) {
+					const n1 = parseInt(t1[i]);
+					const n2 = parseInt(t2[i]);
+					if(n1 == n2) { continue; }
+					return (n1 < n2) ? -1 : 1;
+				}
+				return (t1.length == t2.length) ? 0 : (t1.length < t2.length) ? -1 : 1;
+			}
+
+			const xhr = new XMLHttpRequest();
+			xhr.onreadystatechange = function() {
+				if (this.readyState === XMLHttpRequest.DONE) {
+					if(this.status === 200) {
+						console.log('Available version :', this.responseText);
+						el.classList.remove('red');
+						if(compareVersion(currentVersion, this.responseText) < 0) {
+							el.innerHTML = '<?= $plxAdmin->update_link ?>';
+							el.classList.add('orange');
+						} else {
+							el.innerHTML = "<?= L_PLUXML_UPTODATE.' ('.PLX_VERSION.')' ?>";
+							el.classList.add('green');
+						}
+						return;
+					}
+					console.error('[check update]', this.status, this.statusText);
+				}
+			};
+			xhr.open('GET', '<?= PLX_URL_VERSION ?>');
+			xhr.send();
+		})();
+	</script>
+<?php
+}
 # On inclut le footer
 include __DIR__ .'/foot.php';
 ?>

--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -12,6 +12,7 @@ const PLX_ADMIN = true;
 class plxAdmin extends plxMotor {
 
 	private static $instance = null;
+	public $update_link = PLX_URL_REPO; // overwritten by self::checmMaj()
 
 	/**
 	 * Méthode qui se charger de créer le Singleton plxAdmin
@@ -1216,10 +1217,9 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 	 **/
 	public function checkMaj() {
 
-		$caption='PluXml.org';
-
 		$latest_version = 'L_PLUXML_UPDATE_ERR';
 		$className = '';
+		$this->update_link = sprintf('%s : <a href="%s">%s</a>', L_PLUXML_UPDATE_AVAILABLE, PLX_URL_REPO, PLX_URL_REPO);
 
 		$http_response_header = '';
 		# test avec allow_url_open ou file_get_contents ?
@@ -1260,7 +1260,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 			$className = 'green';
 		}
 		else {
-			$msg = sprintf('%s <a href="%s">%s</a>', L_PLUXML_UPDATE_AVAILABLE, PLX_URL_REPO, $caption);
+			$msg = $this->update_link;
 			$className = 'orange';
 		}
 

--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -928,16 +928,21 @@ class plxUtils {
 	/**
 	 * Méthode qui retourne la liste des langues disponibles dans un tableau
 	 *
-	 * @return	string		chaine de caractères modifiée
-	 * @author	Stephane F.
+	 * @return	tableau associatif
+	 * @author	J.P. Pourrez, Stephane F.
 	 **/
 	public static function getLangs() {
-		$result = array_map(
-			function($dir1) {
-				return preg_replace('#.*/([a-z]{2})$#', '$1', $dir1);
-			},
-			glob(PLX_CORE . 'lang/*', GLOB_ONLYDIR)
-		);
+		$result = array();
+		foreach(
+			array_map(
+				function($dir1) {
+					return preg_replace('#.*/([a-z]{2})$#', '$1', $dir1);
+				},
+				glob(PLX_CORE . 'lang/*', GLOB_ONLYDIR)
+			) as $lang
+		) {
+			$result[$lang] = $lang;
+		}
 		return $result;
 	}
 


### PR DESCRIPTION
Utilise Javascript pour vérifier la mise à jour de PluXml si l'hébergeur du site ne permet d'utiliser curl ou file_get_contents pour les Urls.

Valider avant le pull-request  "Fix plxUtils::getLangs() #370"