### PR TITLE
Medias icons 2003

### DIFF
--- a/core/admin/medias.php
+++ b/core/admin/medias.php
@@ -215,13 +215,13 @@ $curFolders = explode('/', $curFolder);
 						echo '</td>';
 						echo '<td>';
 							echo '<a class="imglink" onclick="'."this.target='_blank'".'" title="'.$title.'" href="'.$v['path'].'">'.$title.$v['extension'].'</a>';
-							echo '<div onclick="copy(this, \''.str_replace(PLX_ROOT, '', $v['path']).'\')" title="'.L_MEDIAS_LINK_COPYCLP.'" class="ico">&#8629;<div>'.L_MEDIAS_LINK_COPYCLP_DONE.'</div></div>';
-							echo '<div id="btnRenameImg'.$num.'" onclick="ImageRename(\''.$v['path'].'\')" title="'.L_RENAME_FILE.'" class="ico">&perp;</div>';
+							echo '<div onclick="copy(this, \''.str_replace(PLX_ROOT, '', $v['path']).'\')" title="'.L_MEDIAS_LINK_COPYCLP.'" class="ico">&#128203;<div>'.L_MEDIAS_LINK_COPYCLP_DONE.'</div></div>';
+							echo '<div id="btnRenameImg'.$num.'" onclick="ImageRename(\''.$v['path'].'\')" title="'.L_RENAME_FILE.'" class="ico">&#9998;</div>';
 							echo '<br />';
 							$href = plxUtils::thumbName($v['path']);
 							if($isImage AND is_file($href)) {
 								echo L_MEDIAS_THUMB.' : '.'<a onclick="'."this.target='_blank'".'" title="'.$title.'" href="'.$href.'">'.plxUtils::strCheck(basename($href)).'</a>';
-								echo '<div onclick="copy(this, \''.str_replace(PLX_ROOT, '', $href).'\')" title="'.L_MEDIAS_LINK_COPYCLP.'" class="ico">&#8629;<div>'.L_MEDIAS_LINK_COPYCLP_DONE.'</div></div>';
+								echo '<div onclick="copy(this, \''.str_replace(PLX_ROOT, '', $href).'\')" title="'.L_MEDIAS_LINK_COPYCLP.'" class="ico">&#128203;<div>'.L_MEDIAS_LINK_COPYCLP_DONE.'</div></div>';
 							}
 						echo '</td>';
 						echo '<td>'.strtoupper($v['extension']).'</td>';

--- a/core/admin/medias.php
+++ b/core/admin/medias.php
@@ -218,13 +218,13 @@ $curFolders = explode('/', $curFolder);
 						echo '</td>';
 						echo '<td>';
 							echo '<a class="imglink" onclick="'."this.target='_blank'".'" title="'.$title.'" href="'.$v['path'].'">'.$title.$v['extension'].'</a>';
-							echo '<div onclick="copy(this, \''.str_replace(PLX_ROOT, '', $v['path']).'\')" title="'.L_MEDIAS_LINK_COPYCLP.'" class="ico">&#128203;<div>'.L_MEDIAS_LINK_COPYCLP_DONE.'</div></div>';
+							echo '<div data-copy="'.str_replace(PLX_ROOT, '', $v['path']).'" title="'.L_MEDIAS_LINK_COPYCLP.'" class="ico">&#128203;<div>'.L_MEDIAS_LINK_COPYCLP_DONE.'</div></div>';
 							echo '<div id="btnRenameImg'.$num.'" onclick="ImageRename(\''.$v['path'].'\')" title="'.L_RENAME_FILE.'" class="ico">&#9998;</div>';
 							echo '<br />';
 							$href = plxUtils::thumbName($v['path']);
 							if($isImage AND is_file($href)) {
 								echo L_MEDIAS_THUMB.' : '.'<a onclick="'."this.target='_blank'".'" title="'.$title.'" href="'.$href.'">'.plxUtils::strCheck(basename($href)).'</a>';
-								echo '<div onclick="copy(this, \''.str_replace(PLX_ROOT, '', $href).'\')" title="'.L_MEDIAS_LINK_COPYCLP.'" class="ico">&#128203;<div>'.L_MEDIAS_LINK_COPYCLP_DONE.'</div></div>';
+								echo '<div data-copy="'.str_replace(PLX_ROOT, '', $href).'" title="'.L_MEDIAS_LINK_COPYCLP.'" class="ico">&#128203;<div>'.L_MEDIAS_LINK_COPYCLP_DONE.'</div></div>';
 							}
 						echo '</td>';
 						echo '<td>'.strtoupper($v['extension']).'</td>';
@@ -353,6 +353,8 @@ $curFolders = explode('/', $curFolder);
 		</div>
 	</div>
 </div>
+
+<input id="clipboard" type="text" value="" style="display: none;" />
 
 <script type="text/javascript" src="<?php echo PLX_CORE ?>lib/medias.js"></script>
 

--- a/core/admin/medias.php
+++ b/core/admin/medias.php
@@ -120,7 +120,21 @@ $curFolders = explode('/', $curFolder);
 
 <?php eval($plxAdmin->plxPlugins->callHook('AdminMediasTop')) # Hook Plugins ?>
 
-<form action="medias.php" method="post" id="form_medias">
+<form method="post">
+	<!-- Rename File Dialog -->
+	<div id="dlgRenameFile" class="dialog">
+		<div class="dialog-content">
+			<?php echo L_MEDIAS_NEW_NAME ?>&nbsp;:&nbsp;
+			<input id="id_newname" type="text" name="newname" value="" maxlength="50" size="15" />
+			<input id="id_oldname" type="hidden" name="oldname" />
+			<?php echo plxToken::getTokenPostMethod() ?>
+			<input type="submit" name="btn_renamefile" value="<?php echo L_MEDIAS_RENAME ?>" />
+			<span class="dialog-close">&times;</span>
+		</div>
+	</div>
+</form>
+
+<form method="post" id="form_medias">
 
 	<!-- New Folder Dialog -->
 	<div id="dlgNewFolder" class="dialog">
@@ -129,17 +143,6 @@ $curFolders = explode('/', $curFolder);
 			<?php echo L_MEDIAS_NEW_FOLDER ?>&nbsp;:&nbsp;
 			<input id="id_newfolder" type="text" name="newfolder" value="" maxlength="50" size="15" />
 			<input type="submit" name="btn_newfolder" value="<?php echo L_MEDIAS_CREATE_FOLDER ?>" />
-		</div>
-	</div>
-
-	<!-- Rename File Dialog -->
-	<div id="dlgRenameFile" class="dialog">
-		<div class="dialog-content">
-			<span class="dialog-close">&times;</span>
-			<?php echo L_MEDIAS_NEW_NAME ?>&nbsp;:&nbsp;
-			<input id="id_newname" type="text" name="newname" value="" maxlength="50" size="15" />
-			<input id="id_oldname" type="hidden" name="oldname" />
-			<input type="submit" name="btn_renamefile" value="<?php echo L_MEDIAS_RENAME ?>" />
 		</div>
 	</div>
 
@@ -195,7 +198,7 @@ $curFolders = explode('/', $curFolder);
 					<th><a href="javascript:void(0)" class="hcolumn" onclick="document.forms[0].sort.value='<?php echo $sort_date ?>';document.forms[0].submit();return true;"><?php echo L_MEDIAS_DATE ?></a></th>
 				</tr>
 				</thead>
-				<tbody>
+				<tbody id="medias-table-tbody">
 				<?php
 				# Initialisation de l'ordre
 				$num = 0;
@@ -344,7 +347,10 @@ $curFolders = explode('/', $curFolder);
 <div class="modal">
 	<input id="modal" type="checkbox" name="modal" tabindex="1">
 	<div id="modal__overlay" class="modal__overlay">
-		<div id="modal__box" class="modal__box"></div>
+		<div id="modal__box" class="modal__box">
+			<img id="zoombox-img" />
+			<label for="modal">&#10006;</label>
+		</div>
 	</div>
 </div>
 

--- a/core/admin/medias.php
+++ b/core/admin/medias.php
@@ -219,7 +219,7 @@ $curFolders = explode('/', $curFolder);
 						echo '<td>';
 							echo '<a class="imglink" onclick="'."this.target='_blank'".'" title="'.$title.'" href="'.$v['path'].'">'.$title.$v['extension'].'</a>';
 							echo '<div data-copy="'.str_replace(PLX_ROOT, '', $v['path']).'" title="'.L_MEDIAS_LINK_COPYCLP.'" class="ico">&#128203;<div>'.L_MEDIAS_LINK_COPYCLP_DONE.'</div></div>';
-							echo '<div id="btnRenameImg'.$num.'" onclick="ImageRename(\''.$v['path'].'\')" title="'.L_RENAME_FILE.'" class="ico">&#9998;</div>';
+							echo '<div data-rename="'.$v['path'].'" title="'.L_RENAME_FILE.'" class="ico">&#9998;</div>';
 							echo '<br />';
 							$href = plxUtils::thumbName($v['path']);
 							if($isImage AND is_file($href)) {

--- a/core/admin/theme/theme.css
+++ b/core/admin/theme/theme.css
@@ -633,6 +633,7 @@ th.checkbox {
 }
 
 .modal__box {
+	position: relative;
 	text-align: center;
 }
 
@@ -645,6 +646,8 @@ th.checkbox {
 }
 
 .modal label {
+	position: absolute;
+	right: 0;
 	background-color: #444;
 	color: #fff;
 	cursor: pointer;
@@ -674,7 +677,8 @@ th.checkbox {
 }
 
 .modal__box img {
-	max-height: 100%;
+	max-height: 100vh;
+	max-width: 100vw;
 }
 
 .modal__overlay {
@@ -775,6 +779,10 @@ div.ico div {
 	color: #000;
 	font-size: 16pt;
 	margin: 0 0.3rem;
+}
+
+a.overlay {
+	display: block;
 }
 
 /* The Dialog (background) */

--- a/core/admin/theme/theme.css
+++ b/core/admin/theme/theme.css
@@ -771,6 +771,12 @@ div.ico div {
 	border: 1px solid #888;
 }
 
+#medias-table div.ico {
+	color: #000;
+	font-size: 16pt;
+	margin: 0 0.3rem;
+}
+
 /* The Dialog (background) */
 
 .dialog {

--- a/core/lib/medias.js
+++ b/core/lib/medias.js
@@ -1,15 +1,17 @@
 // zoombox
-var all = document.getElementById('medias-table-tbody');
+var tbody = document.getElementById('medias-table-tbody');
 var mo = document.getElementById("modal__overlay");
-var mbox = document.getElementById("modal__box");
+// var mbox = document.getElementById("modal__box");
 var mb = document.getElementById("modal");
 var zoomboxImg = document.getElementById('zoombox-img');
-all.addEventListener('click', function(event) {
+tbody.addEventListener('click', function(event) {
 	if(event.target.classList.contains('thumb') && event.target.tagName ==  'IMG') {
 		event.preventDefault();
 		const src = event.target.src.replace(/\/.thumbs?\b/, '');
+		const title = src.replace(/.*\/([^\/]*)$/, '$1');
 		zoomboxImg.src = src;
-		zoomboxImg.alt = src.replace(/.*\/([^\/]*)$/, '$1');
+		zoomboxImg.alt = title;
+		zoomboxImg.title = title;
 		mb.checked = true;
 	}
 });

--- a/core/lib/medias.js
+++ b/core/lib/medias.js
@@ -1,29 +1,28 @@
 // zoombox
-var all = document.querySelectorAll(".overlay");
+var all = document.getElementById('medias-table-tbody');
 var mo = document.getElementById("modal__overlay");
 var mbox = document.getElementById("modal__box");
 var mb = document.getElementById("modal");
-for (var i = 0, nb = all.length; i < nb; i++) {
-	all[i].addEventListener('click', function(e) {
-		e.preventDefault();
-		mbox.innerHTML = '<img src="'+this.href+'" alt="" /><label for="modal">&#10006;</label>';
-		mb.click();
-	},false);
-}
+var zoomboxImg = document.getElementById('zoombox-img');
+all.addEventListener('click', function(event) {
+	if(event.target.classList.contains('thumb') && event.target.tagName ==  'IMG') {
+		event.preventDefault();
+		const src = event.target.src.replace(/\/.thumbs?\b/, '');
+		zoomboxImg.src = src;
+		zoomboxImg.alt = src.replace(/.*\/([^\/]*)$/, '$1');
+		mb.checked = true;
+	}
+});
 window.addEventListener("keydown", function (event) {
 	// validate if the press key is the escape key
 	if (event.code=="Escape" || event.key=="Escape" || event.keyCode==27) {
-    	mbox.innerHTML = "";
-    	if (mb.checked === true) {
-    		mb.click();
-    	}
+    	event.preventDefault();
+    	mb.checked = false;
     }
 });
 mo.addEventListener("click", function (event) {
-   	mbox.innerHTML = "";
-   	if (mb.checked === true) {
-   		mb.click();
-   	}
+	event.preventDefault();
+   	mb.checked = false;
 });
 
 function toggle_divs(){
@@ -41,7 +40,7 @@ function copy(elt, data) {
 	try {
 		var div = elt.querySelector("div");
 		var aux = document.createElement("input");
-		aux.setAttribute("value", data);
+		aux.value = data;
 		document.body.appendChild(aux);
 		aux.select();
 		document.execCommand("copy");

--- a/core/lib/medias.js
+++ b/core/lib/medias.js
@@ -39,6 +39,13 @@ tbody.addEventListener('click', function(event) {
 		aux.style.display = 'none';
 		return;
 	}
+
+	if(event.target.hasAttribute('data-rename')) {
+		event.preventDefault();
+		document.getElementById('id_oldname').value = event.target.dataset.rename;
+		dialogBox("dlgRenameFile");
+		return;
+	}
 });
 window.addEventListener("keydown", function (event) {
 	// validate if the press key is the escape key
@@ -86,9 +93,4 @@ if (typeof(Storage) !== "undefined" && localStorage.getItem("medias_search") !==
 	input = document.getElementById("medias-search");
 	input.value = localStorage.getItem("medias_search");
 	plugFilter();
-}
-
-function ImageRename(oldimg) {
-	document.getElementById('id_oldname').value = oldimg;
-	dialogBox("dlgRenameFile");
 }

--- a/core/lib/medias.js
+++ b/core/lib/medias.js
@@ -13,6 +13,31 @@ tbody.addEventListener('click', function(event) {
 		zoomboxImg.alt = title;
 		zoomboxImg.title = title;
 		mb.checked = true;
+		return;
+	}
+
+	if(event.target.hasAttribute('data-copy')) {
+		event.preventDefault();
+		const aux = document.getElementById('clipboard');
+		if(aux == null) {
+			console.error('#clipboard element not found');
+			return;
+		}
+
+		aux.style.display = 'initial';
+		aux.value = event.target.dataset.copy;
+		aux.select();
+		document.execCommand('copy');
+		const notice = event.target.firstElementChild;
+		notice.style.display = 'inline-block';
+		var t = setTimeout(function() {
+			aux.value = '';
+			notice.style.display = 'none';
+			clearTimeout(t);
+		}, 1000);
+		aux.value = '';
+		aux.style.display = 'none';
+		return;
 	}
 });
 window.addEventListener("keydown", function (event) {
@@ -26,7 +51,6 @@ mo.addEventListener("click", function (event) {
 	event.preventDefault();
    	mb.checked = false;
 });
-
 function toggle_divs(){
 	var uploader = document.getElementById('files_uploader');
 	var manager = document.getElementById('files_manager');
@@ -36,24 +60,6 @@ function toggle_divs(){
 	} else {
 		uploader.style.display = 'none';
 		manager.style.display = 'block';
-	}
-}
-function copy(elt, data) {
-	try {
-		var div = elt.querySelector("div");
-		var aux = document.createElement("input");
-		aux.value = data;
-		document.body.appendChild(aux);
-		aux.select();
-		document.execCommand("copy");
-		document.body.removeChild(aux);
-		div.setAttribute("style", "display:inline-block");
-		t = setTimeout(function(){
-			div.setAttribute("style", "display:none");
-			clearTimeout(t);
-		}, 1000);
-	} catch (err) {
-		alert('<?php echo L_MEDIAS_LINK_COPYCLP_ERR ?>');
 	}
 }
 function plugFilter() {


### PR DESCRIPTION
Voir fil de discussion ici : https://forum.pluxml.org/discussion/4532/plugin-tinymce-editeur-pour-articles-et-pages-statiques#latest

Les icônes employées dans le gestionnaire de médias ne sont pas très explcites. Il n'est donc pas évident de comprendre qu'une icône permet de copier d'un clic l'url d'une image.
Il existe des entities HTML plus explicites avec ce PR.

Autre souci résolu : la toucher "entrée" ne fonctionne pas quand on renomme une image et oblige à cliquer sur un bouton avec la souris. => perte de temps

Toute la floppée de onclick pour les images est remplacée par un écouteur d'évènements sur la balise "<tbody>". Ca simplifie la gestion et cela va certainement plus vite.