### PR TITLE
Création des constantes PROFIL_NAMES, IMG_REDIM et IMG_THUMB

### DIFF
--- a/core/admin/medias.php
+++ b/core/admin/medias.php
@@ -296,7 +296,7 @@ $curFolders = explode('/', $curFolder);
 					<li><?php echo L_MEDIAS_RESIZE ?>&nbsp;:&nbsp;</li>
 					<li><input type="radio" checked="checked" name="resize" value="" />&nbsp;<?php echo L_MEDIAS_RESIZE_NO ?></li>
 					<?php
-						foreach($img_redim as $redim) {
+						foreach(IMG_REDIM as $redim) {
 							echo '<li><input type="radio" name="resize" value="'.$redim.'" />&nbsp;'.$redim.'</li>';
 						}
 					?>
@@ -319,7 +319,7 @@ $curFolders = explode('/', $curFolder);
 						<input<?php echo $sel ?> type="radio" name="thumb" value="" />&nbsp;<?php echo L_MEDIAS_THUMBS_NONE ?>
 					</li>
 					<?php
-						foreach($img_thumb as $thumb) {
+						foreach(IMG_THUMB as $thumb) {
 							echo '<li><input type="radio" name="thumb" value="'.$thumb.'" />&nbsp;'.$thumb.'</li>';
 						}
 					?>

--- a/core/admin/parametres_users.php
+++ b/core/admin/parametres_users.php
@@ -21,15 +21,6 @@ if (!empty($_POST)) {
 	exit;
 }
 
-# Tableau des profils
-$aProfils = array(
-	PROFIL_ADMIN => L_PROFIL_ADMIN,
-	PROFIL_MANAGER => L_PROFIL_MANAGER,
-	PROFIL_MODERATOR => L_PROFIL_MODERATOR,
-	PROFIL_EDITOR => L_PROFIL_EDITOR,
-	PROFIL_WRITER => L_PROFIL_WRITER
-);
-
 # On inclut le header
 include __DIR__ .'/top.php';
 ?>
@@ -84,11 +75,11 @@ include __DIR__ .'/top.php';
 				if($_userid=='001') {
 					plxUtils::printInput($_userid.'_profil', $_user['profil'], 'hidden');
 					plxUtils::printInput($_userid.'_active', $_user['active'], 'hidden');
-					plxUtils::printSelect($_userid.'__profil', $aProfils, $_user['profil'], true, 'readonly');
+					plxUtils::printSelect($_userid.'__profil', PROFIL_NAMES, $_user['profil'], true, 'readonly');
 					echo '</td><td>';
 					plxUtils::printSelect($_userid.'__active', array('1'=>L_YES,'0'=>L_NO), $_user['active'], true, 'readonly');
 				} else {
-					plxUtils::printSelect($_userid.'_profil', $aProfils, $_user['profil']);
+					plxUtils::printSelect($_userid.'_profil', PROFIL_NAMES, $_user['profil']);
 					echo '</td><td>';
 					plxUtils::printSelect($_userid.'_active', array('1'=>L_YES,'0'=>L_NO), $_user['active']);
 				}
@@ -120,7 +111,7 @@ include __DIR__ .'/top.php';
 				echo '</td><td>';
 				plxUtils::printInput($new_userid.'_email', '', 'email', '');
 				echo '</td><td>';
-				plxUtils::printSelect($new_userid.'_profil', $aProfils, PROFIL_WRITER);
+				plxUtils::printSelect($new_userid.'_profil', PROFIL_NAMES, PROFIL_WRITER);
 				echo '</td><td>';
 				plxUtils::printSelect($new_userid.'_active', array('1'=>L_YES,'0'=>L_NO), '1');
 				echo '</td>';

--- a/core/admin/prepend.php
+++ b/core/admin/prepend.php
@@ -68,6 +68,15 @@ eval($plxAdmin->plxPlugins->callHook('AdminPrepend'));
 loadLang(PLX_CORE.'lang/'.$lang.'/admin.php');
 loadLang(PLX_CORE.'lang/'.$lang.'/core.php');
 
+# Tableau des profils
+const PROFIL_NAMES = array(
+	PROFIL_ADMIN		=> L_PROFIL_ADMIN,
+	PROFIL_MANAGER		=> L_PROFIL_MANAGER,
+	PROFIL_MODERATOR	=> L_PROFIL_MODERATOR,
+	PROFIL_EDITOR		=> L_PROFIL_EDITOR,
+	PROFIL_WRITER		=> L_PROFIL_WRITER
+);
+
 # on stocke la langue utilisée pour l'affichage de la zone d'administration en variable de session
 # nb: la langue peut etre modifiée par le hook AdminPrepend via des plugins
 $_SESSION['admin_lang'] = $lang;

--- a/core/admin/top.php
+++ b/core/admin/top.php
@@ -60,13 +60,7 @@ if(isset($_GET["del"]) AND $_GET["del"]=="install") {
 				</li>
 				<li>
 					<strong><?php echo plxUtils::strCheck($plxAdmin->aUsers[$_SESSION['user']]['name']) ?></strong>&nbsp;:
-					<em>
-						<?php if($_SESSION['profil']==PROFIL_ADMIN) echo L_PROFIL_ADMIN;
-						elseif($_SESSION['profil']==PROFIL_MANAGER) echo L_PROFIL_MANAGER;
-						elseif($_SESSION['profil']==PROFIL_MODERATOR) echo L_PROFIL_MODERATOR;
-						elseif($_SESSION['profil']==PROFIL_EDITOR) echo L_PROFIL_EDITOR;
-						else echo L_PROFIL_WRITER; ?>
-					</em>
+					<em><?php echo PROFIL_NAMES[$_SESSION['profil']]; ?></em>
 				</li>
 				<li><small><a class="version" title="PluXml" href="<?php echo PLX_URL_REPO ?>">PluXml <?php echo $plxAdmin->aConf['version'] ?></a></small></li>
 			</ul>

--- a/core/lib/config.php
+++ b/core/lib/config.php
@@ -32,15 +32,15 @@ const PLX_CHARSET = 'UTF-8';
 const DEFAULT_LANG = 'en';
 
 # profils utilisateurs de pluxml
-const PROFIL_ADMIN = 0;
-const PROFIL_MANAGER = 1;
+const PROFIL_ADMIN		= 0;
+const PROFIL_MANAGER	= 1;
 const PROFIL_MODERATOR	= 2;
-const PROFIL_EDITOR	= 3;
-const PROFIL_WRITER	= 4;
+const PROFIL_EDITOR		= 3;
+const PROFIL_WRITER		= 4;
 
 # taille redimensionnement des images et miniatures
-$img_redim = array('320x200', '500x380', '640x480');
-$img_thumb = array('50x50', '75x75', '100x100');
+const IMG_REDIM = array('320x200', '500x380', '640x480');
+const IMG_THUMB = array('50x50', '75x75', '100x100');
 
 # On sécurise notre environnement si dans php.ini: register_globals = On
 if (ini_get('register_globals')) {


### PR DESCRIPTION
PHP 5.6 permet de créer des constantes tableaux !
PROFIL_NAMES est utilisé dans top.php et parametres_user.php
Et éventuellement dans des plugins pour fixer certains droits