### PR TITLE
Extraction de l'Url des ressources dans les traductions

### DIFF
--- a/core/admin/parametres_themes.php
+++ b/core/admin/parametres_themes.php
@@ -100,7 +100,10 @@ $plxThemes = new plxThemes(PLX_ROOT.$plxAdmin->aConf['racine_themes'], $plxAdmin
 
 	<div class="inline-form action-bar">
 		<h2><?php echo L_CONFIG_VIEW_SKIN_SELECT ?> </h2>
-		<p><?php echo L_CONFIG_VIEW_PLUXML_RESSOURCES ?></p>
+		<p><?php
+			$tag = '<a href="' . PLX_URL_RESSOURCES . '" target="_blank">' . PLX_URL_RESSOURCES . '</a>';
+			printf(L_CONFIG_VIEW_PLUXML_RESSOURCES, $tag);
+		?></p>
 		<input type="submit" value="<?php echo L_CONFIG_THEME_UPDATE ?>" />
 		<span class="sml-hide med-show">&nbsp;&nbsp;&nbsp;</span>
 		<input onclick="window.location.assign('parametres_edittpl.php');return false" type="submit" value="<?php echo L_TEMPLATES_EDIT ?>" />

--- a/core/lang/de/admin.php
+++ b/core/lang/de/admin.php
@@ -313,7 +313,7 @@ const L_CONFIG_VIEW_IMAGES = 'Bildgröße (Breite x Höhe)';
 const L_CONFIG_VIEW_THUMBS = 'Größe der Miniaturansicht (Breite x Höhe)';
 const L_CONFIG_VIEW_HOMESTATIC = 'Eine statische Seite als Homepage verwenden';
 const L_CONFIG_VIEW_HOMESTATIC_ACTIVE = 'Achtung! Diese Seite ist inaktiv';
-const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Themen von <a href="http://ressources.pluxml.org">ressources.pluxml.org</a> laden.';
+const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Themen von %s laden.';
 const L_CONFIG_VIEW_BYPAGE_FEEDS = 'Anzahl der angezeigten Artikel/Kommentare im RSS Feed';
 const L_CONFIG_VIEW_FEEDS_HEADLINE = 'Im RSS Feed nur Vorspann des Artikels zeigen';
 const L_CONFIG_VIEW_FEEDS_HEADLINE_HELP = 'Wenn der Vorspann leer ist, Inhalt anzeigen';

--- a/core/lang/en/admin.php
+++ b/core/lang/en/admin.php
@@ -311,7 +311,7 @@ const L_CONFIG_VIEW_IMAGES = 'Image Size (width x height)';
 const L_CONFIG_VIEW_THUMBS = 'Thumbnails size (width x height)';
 const L_CONFIG_VIEW_HOMESTATIC = 'Use a static page as Homepage';
 const L_CONFIG_VIEW_HOMESTATIC_ACTIVE = 'Warning: this page is inactive';
-const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Download themes at <a href="http://ressources.pluxml.org">ressources.pluxml.org</a>.';
+const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Download themes at : %s';
 const L_CONFIG_VIEW_BYPAGE_FEEDS = 'N° of Articles or comments in the Rss feed';
 const L_CONFIG_VIEW_FEEDS_HEADLINE = 'Only display headlines in the Rss article feed';
 const L_CONFIG_VIEW_FEEDS_HEADLINE_HELP = 'Headline field is empty, content is displayed instead';

--- a/core/lang/es/admin.php
+++ b/core/lang/es/admin.php
@@ -309,7 +309,7 @@ const L_CONFIG_VIEW_IMAGES = 'Tamaño de la imagen (largo x ancho)';
 const L_CONFIG_VIEW_THUMBS = 'Tamaño de las miniaturas (largo x ancho)';
 const L_CONFIG_VIEW_HOMESTATIC = 'Utilizar una página estática como página de inicio';
 const L_CONFIG_VIEW_HOMESTATIC_ACTIVE = 'Advertencia: esta página está desactivada';
-const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Descargar otros temas en <a href="http://ressources.pluxml.org">ressources.pluxml.org</a>.';
+const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Descargar otros temas en : %s';
 const L_CONFIG_VIEW_BYPAGE_FEEDS = 'Cantidad de artículos en la sindicación RSS';
 const L_CONFIG_VIEW_FEEDS_HEADLINE = 'Sómo mostrar subtítulos en la sindicación RSS de los artículos';
 const L_CONFIG_VIEW_FEEDS_HEADLINE_HELP = 'En caso de que el subtítulo esté vacío, se mostrará el contenido';

--- a/core/lang/fr/admin.php
+++ b/core/lang/fr/admin.php
@@ -310,7 +310,7 @@ const L_CONFIG_VIEW_IMAGES = 'Taille des images (largeur x hauteur)';
 const L_CONFIG_VIEW_THUMBS = 'Taille des miniatures (largeur x hauteur)';
 const L_CONFIG_VIEW_HOMESTATIC = 'Utiliser une page statique comme page d\'accueil';
 const L_CONFIG_VIEW_HOMESTATIC_ACTIVE = 'Attention cette page est inactive';
-const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Télécharger d\'autres thèmes sur <a href="http://ressources.pluxml.org">ressources.pluxml.org</a>.';
+const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Télécharger d\'autres thèmes sur : %s';
 const L_CONFIG_VIEW_BYPAGE_FEEDS = 'Nombre d\'articles/commentaires affichés sur les fils RSS';
 const L_CONFIG_VIEW_FEEDS_HEADLINE = 'Afficher uniquement le chapô dans les flux RSS des articles';
 const L_CONFIG_VIEW_FEEDS_HEADLINE_HELP = 'Si le chapô est vide, le contenu est affiché';

--- a/core/lang/it/admin.php
+++ b/core/lang/it/admin.php
@@ -264,7 +264,7 @@ const L_CONFIG_VIEW_IMAGES = 'Immagine Dimensioni (larghezza x altezza)';
 const L_CONFIG_VIEW_THUMBS = 'Dimensione delle miniature (larghezza x altezza)';
 const L_CONFIG_VIEW_HOMESTATIC = 'Usa una pagina statica come homepage';
 const L_CONFIG_VIEW_HOMESTATIC_ACTIVE = 'Attenzione, questa pagina non è attiva';
-const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Scarica altri temi su <a href="http://ressources.pluxml.org">ressources.pluxml.org</a>.';
+const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Scarica altri temi su : %s';
 const L_CONFIG_VIEW_BYPAGE_FEEDS = 'Numero di articoli/commenti visualizzati';
 const L_CONFIG_VIEW_FEEDS_HEADLINE = 'Visualizzare solo la premessa degli articoli';
 const L_CONFIG_VIEW_FEEDS_HEADLINE_HELP = 'Se la premessa è vuota, visualizza il contenuto';

--- a/core/lang/nl/admin.php
+++ b/core/lang/nl/admin.php
@@ -298,7 +298,7 @@ const L_CONFIG_VIEW_IMAGES = 'Beeldformaat (breedte x hoogte)';
 const L_CONFIG_VIEW_THUMBS = 'Grootte thumbnails (breedte x hoogte)';
 const L_CONFIG_VIEW_HOMESTATIC = 'een statische pagina als verwelkomingspagina gebruiken';
 const L_CONFIG_VIEW_HOMESTATIC_ACTIVE = 'Opgelet. Deze pagina is niet actief';
-const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Nieuwe layouts downloaden op <a href="http://ressources.pluxml.org">ressources.pluxml.org</a>.';
+const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Nieuwe layouts downloaden op : %s';
 const L_CONFIG_VIEW_BYPAGE_FEEDS = 'Aantal artikels/commentaar in RSS feed';
 const L_CONFIG_VIEW_FEEDS_HEADLINE = 'Korte samenvatting in RSS feed opnemen';
 const L_CONFIG_VIEW_FEEDS_HEADLINE_HELP = 'Indien samenvatting leeg is zal artikelinhoud getoond worden';

--- a/core/lang/oc/admin.php
+++ b/core/lang/oc/admin.php
@@ -310,7 +310,7 @@ const L_CONFIG_VIEW_IMAGES = 'Talha dels imatges (largor x nautor)';
 const L_CONFIG_VIEW_THUMBS = 'Talha de las miniaturas (largor x nautor)';
 const L_CONFIG_VIEW_HOMESTATIC = 'Utilizar una pagina estatica coma pagina d\'acuèlh';
 const L_CONFIG_VIEW_HOMESTATIC_ACTIVE = 'Atencion aquela pagina es inactiva';
-const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Telecargar mai tèmas sus <a href="http://ressources.pluxml.org">ressources.pluxml.org</a>.';
+const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Telecargar mai tèmas sus : %s';
 const L_CONFIG_VIEW_BYPAGE_FEEDS = 'Nombre d\'articles/comentaris afichats suls fils Rss';
 const L_CONFIG_VIEW_FEEDS_HEADLINE = 'Afichar pas que lo chapô dins los flux Rss dels articles';
 const L_CONFIG_VIEW_FEEDS_HEADLINE_HELP = 'Se lo chapô es void, lo contengut es afichat';

--- a/core/lang/pl/admin.php
+++ b/core/lang/pl/admin.php
@@ -309,7 +309,7 @@ const L_CONFIG_VIEW_IMAGES = 'Taille des images (largeur x hauteur)';
 const L_CONFIG_VIEW_THUMBS = 'Taille des miniatures (largeur x hauteur)';
 const L_CONFIG_VIEW_HOMESTATIC = 'Utiliser une page statique comme page d\'accueil';
 const L_CONFIG_VIEW_HOMESTATIC_ACTIVE = 'Attention cette page est inactive';
-const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Télécharger d\'autres thèmes sur <a href="http://ressources.pluxml.org">ressources.pluxml.org</a>.';
+const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Télécharger d\'autres thèmes sur : %s';
 const L_CONFIG_VIEW_BYPAGE_FEEDS = 'Nombre d\'articles/commentaires affichés sur les fils Rss';
 const L_CONFIG_VIEW_FEEDS_HEADLINE = 'Afficher uniquement le chapô dans les flux Rss des articles';
 const L_CONFIG_VIEW_FEEDS_HEADLINE_HELP = 'Si le chapô est vide, le contenu est affiché';

--- a/core/lang/pt/admin.php
+++ b/core/lang/pt/admin.php
@@ -267,7 +267,7 @@ const L_CONFIG_VIEW_IMAGES = 'Tamanho da imagem (largura x altura)';
 const L_CONFIG_VIEW_THUMBS = 'Tamanhos das miniaturas (largura x altura)';
 const L_CONFIG_VIEW_HOMESTATIC = 'Utilizar uma página stática como página de índice';
 const L_CONFIG_VIEW_HOMESTATIC_ACTIVE = 'Atenção esta página está inactiva';
-const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Descarregue outros temas em <a href="http://ressources.pluxml.org">ressources.pluxml.org</a>.';
+const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Descarregue outros temas em : %s';
 const L_CONFIG_VIEW_BYPAGE_FEEDS = 'Numero de artigos/comentários exibidoss nops fluxos Rss';
 const L_CONFIG_VIEW_FEEDS_HEADLINE = 'Mostrar sómente o chapéu dos artigos nos fluxos Rss';
 const L_CONFIG_VIEW_FEEDS_HEADLINE_HELP = 'Se o chapéu estiver vazio o conteúdo será exibido';

--- a/core/lang/ro/admin.php
+++ b/core/lang/ro/admin.php
@@ -264,7 +264,7 @@ const L_CONFIG_VIEW_IMAGES = 'Dimensiune imagine (latime x inaltime)';
 const L_CONFIG_VIEW_THUMBS = 'Thumbnail dimensiuni (latime x inaltime)';
 const L_CONFIG_VIEW_HOMESTATIC = 'Utilizaţi o pagină statică ca Home-page';
 const L_CONFIG_VIEW_HOMESTATIC_ACTIVE = 'Atenţie, această pagină este inactivă';
-const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Descarcă alte teme <a href="http://ressources.pluxml.org">ressources.pluxml.org</a>.';
+const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Descarcă alte teme : %s';
 const L_CONFIG_VIEW_BYPAGE_FEEDS = 'Numărul de articole	şi comentarii postate pe fluxul Rss';
 const L_CONFIG_VIEW_FEEDS_HEADLINE = 'Vezi Headerul în articolele RSS';
 const L_CONFIG_VIEW_FEEDS_HEADLINE_HELP = 'Dacă headerul este gol, conţinutul este afişat';

--- a/core/lang/ru/admin.php
+++ b/core/lang/ru/admin.php
@@ -312,7 +312,7 @@ const L_CONFIG_VIEW_IMAGES = 'Размер изображения (Ширина 
 const L_CONFIG_VIEW_THUMBS = 'Размер эскизов (Ширина х Высота)';
 const L_CONFIG_VIEW_HOMESTATIC = 'Использовать статическую страницу как Главную страницу';
 const L_CONFIG_VIEW_HOMESTATIC_ACTIVE = 'Внимание: Эта страница неактивна';
-const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Загрузка тем <a href="http://ressources.pluxml.org">ressources.pluxml.org</a>.';
+const L_CONFIG_VIEW_PLUXML_RESSOURCES = 'Загрузка тем %s';
 const L_CONFIG_VIEW_BYPAGE_FEEDS = 'N° статьи или комментария в RSS-потоке';
 const L_CONFIG_VIEW_FEEDS_HEADLINE = 'Отображать только заголовки статей в RSS-потоке';
 const L_CONFIG_VIEW_FEEDS_HEADLINE_HELP = 'Поле Заголовка пустое, вместо него отображается содержимое статьи';

--- a/core/lib/config.php
+++ b/core/lib/config.php
@@ -2,6 +2,7 @@
 const PLX_DEBUG = false;
 const PLX_VERSION = '5.8.3';
 const PLX_URL_REPO = 'https://www.pluxml.org';
+const PLX_URL_RESSOURCES = 'https://ressources.pluxml.org';
 const PLX_URL_VERSION = PLX_URL_REPO.'/download/latest-version.txt';
 
 # Gestion des erreurs PHP


### PR DESCRIPTION
Attention à la syntaxe allemande
http:// => https:// !!!