### PR TITLE
Utilisation de PLX_DATA_PATH pour la configuration et gestion des thèmes et plugins dans le config.php

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,3 +1,7 @@
 <?php
-const PLX_CONFIG_PATH = 'data/configuration/';
+const PLX_DATA_PATH = PLX_ROOT.'data/';
+const PLX_CONFIG_PATH = PLX_DATA_PATH.'configuration/';
+
+const PLX_PLUGINS_PATH = PLX_ROOT.'plugins/';
+const PLX_THEMES_PATH = PLX_ROOT.'themes/';
 ?>

--- a/core/admin/article.php
+++ b/core/admin/article.php
@@ -178,7 +178,7 @@ if(!empty($_POST)) { # Création, mise à jour, suppression ou aperçu
 		exit;
 	}
 	# On parse et alimente nos variables
-	$result = $plxAdmin->parseArticle(PLX_ROOT.$plxAdmin->aConf['racine_articles'].$aFile['0']);
+	$result = $plxAdmin->parseArticle($plxAdmin->aConf['racine_articles'].$aFile['0']);
 	$title = trim($result['title']);
 	$chapo = trim($result['chapo']);
 	$content = trim($result['content']);
@@ -251,7 +251,7 @@ foreach($plxAdmin->aUsers as $_userid => $_user) {
 
 # On récupère les templates des articles
 $aTemplates = array();
-$files = plxGlob::getInstance(PLX_ROOT.$plxAdmin->aConf['racine_themes'].$plxAdmin->aConf['style']);
+$files = plxGlob::getInstance($plxAdmin->aConf['racine_themes'].$plxAdmin->aConf['style']);
 if ($array = $files->query('/^article(-[a-z0-9-_]+)?.php$/')) {
 	foreach($array as $k=>$v)
 		$aTemplates[$v] = $v;

--- a/core/admin/categorie.php
+++ b/core/admin/categorie.php
@@ -38,7 +38,7 @@ elseif(!empty($_GET['p'])) { # On vérifie l'existence de la catégorie
 
 # On récupère les templates des catégories
 $aTemplates = array();
-$files = plxGlob::getInstance(PLX_ROOT.$plxAdmin->aConf['racine_themes'].$plxAdmin->aConf['style']);
+$files = plxGlob::getInstance($plxAdmin->aConf['racine_themes'].$plxAdmin->aConf['style']);
 if ($array = $files->query('/^categorie(-[a-z0-9-_]+)?.php$/')) {
 	foreach($array as $k=>$v)
 		$aTemplates[$v] = $v;

--- a/core/admin/comment.php
+++ b/core/admin/comment.php
@@ -89,7 +89,7 @@ if(($aFile = $plxAdmin->plxGlob_arts->query('/^'.$artId.'.(.+).xml$/','','sort',
 	# Statut du commentaire
 	$statut = '<strong>'.L_COMMENT_ORPHAN_STATUS.'</strong>';
 } else {
-	$result = $plxAdmin->parseArticle(PLX_ROOT.$plxAdmin->aConf['racine_articles'].$aFile['0']);
+	$result = $plxAdmin->parseArticle($plxAdmin->aConf['racine_articles'].$aFile['0']);
 	# On génère notre lien
 	$article = '<a href="'.$plxAdmin->urlRewrite('?article'.intval($result['numero']).'/'.$result['url']).'" title="'.L_COMMENT_ARTICLE_LINKED_TITLE.'">';
 	$article .= plxUtils::strCheck($result['title']);

--- a/core/admin/comment_new.php
+++ b/core/admin/comment_new.php
@@ -70,7 +70,7 @@ if(!empty($_GET['c'])) { # Mode "answer"
 	# Variables de traitement
 	if(!empty($_GET['a'])) $get = 'c='.$_GET['c'].'&amp;a='.$_GET['a'];
 	else $get = 'c='.$_GET['c'];
-	$aArt = $plxAdmin->parseArticle(PLX_ROOT.$plxAdmin->aConf['racine_articles'].$aFile['0']);
+	$aArt = $plxAdmin->parseArticle($plxAdmin->aConf['racine_articles'].$aFile['0']);
 	# Variable du formulaire
 	$content = '';
 	$article = '<a href="article.php?a='.$aArt['numero'].'" title="'.L_COMMENT_ARTICLE_LINKED_TITLE.'">';
@@ -94,7 +94,7 @@ if(!empty($_GET['c'])) { # Mode "answer"
 	# Variables de traitement
 	$artId = $_GET['a'];
 	$get = 'a='.$_GET['a'];
-	$aArt = $plxAdmin->parseArticle(PLX_ROOT.$plxAdmin->aConf['racine_articles'].$aFile['0']);
+	$aArt = $plxAdmin->parseArticle($plxAdmin->aConf['racine_articles'].$aFile['0']);
 	# Variable du formulaire
 	$content = '';
 	$article = '<a href="article.php?a='.$aArt['numero'].'" title="'.L_COMMENT_ARTICLE_LINKED_TITLE.'">';

--- a/core/admin/comments.php
+++ b/core/admin/comments.php
@@ -53,7 +53,7 @@ if(!empty($_GET['a'])) {
 		exit;
 	}
 	# Infos sur l'article
-	$aArt = $plxAdmin->parseArticle(PLX_ROOT.$plxAdmin->aConf['racine_articles'].$globArt['0']);
+	$aArt = $plxAdmin->parseArticle($plxAdmin->aConf['racine_articles'].$globArt['0']);
 	$portee = ucfirst(L_ARTICLE) . ' &laquo;' . $aArt['title'] . '&raquo;';
 } else { # Commentaires globaux
 	$portee = '';

--- a/core/admin/medias.php
+++ b/core/admin/medias.php
@@ -30,7 +30,7 @@ elseif(!empty($_POST['folder'])) {
 	$_SESSION['folder'] = ($_POST['folder']=='.'?'':$_POST['folder']);
 }
 # Nouvel objet de type plxMedias
-$plxMediasRoot = PLX_ROOT.$_SESSION['medias'];
+$plxMediasRoot = $_SESSION['medias'];
 if($plxAdmin->aConf['userfolders'] AND $_SESSION['profil']==PROFIL_WRITER)
 	$plxMediasRoot .= $_SESSION['user'].'/';
 $plxMedias = new plxMedias($plxMediasRoot, $_SESSION['folder'], $plxAdmin->aConf['default_lang']);

--- a/core/admin/parametres_affichage.php
+++ b/core/admin/parametres_affichage.php
@@ -30,7 +30,7 @@ if(!empty($_POST)) {
 
 # On récupère les templates de la page d'accueil
 $aTemplates = array();
-$files = plxGlob::getInstance(PLX_ROOT.$plxAdmin->aConf['racine_themes'].$plxAdmin->aConf['style']);
+$files = plxGlob::getInstance($plxAdmin->aConf['racine_themes'].$plxAdmin->aConf['style']);
 if ($array = $files->query('/^home(-[a-z0-9-_]+)?.php$/')) {
 	foreach($array as $k=>$v)
 		$aTemplates[$v] = $v;

--- a/core/admin/parametres_edittpl.php
+++ b/core/admin/parametres_edittpl.php
@@ -18,14 +18,14 @@ $tpl = isset($_POST['tpl'])?$_POST['tpl']:'home.php';
 if(!empty($_POST['load'])) $tpl = $_POST['template'];
 
 $style = $plxAdmin->aConf['style'];
-$filename = realpath(PLX_ROOT.$plxAdmin->aConf['racine_themes'].$style.'/'.$tpl);
-if(!preg_match('#^'.str_replace('\\', '/', realpath(PLX_ROOT.$plxAdmin->aConf['racine_themes'].$style.'/').'#'), str_replace('\\', '/', $filename))) {
+$filename = realpath($plxAdmin->aConf['racine_themes'].$style.'/'.$tpl);
+if(!preg_match('#^'.str_replace('\\', '/', realpath($plxAdmin->aConf['racine_themes'].$style.'/').'#'), str_replace('\\', '/', $filename))) {
 	$tpl='home.php';
 }
-$filename = realpath(PLX_ROOT.$plxAdmin->aConf['racine_themes'].$style.'/'.$tpl);
+$filename = realpath($plxAdmin->aConf['racine_themes'].$style.'/'.$tpl);
 
 # On teste l'existence du thème
-if(empty($style) OR !is_dir(PLX_ROOT.$plxAdmin->aConf['racine_themes'].$style)) {
+if(empty($style) OR !is_dir($plxAdmin->aConf['racine_themes'].$style)) {
 	plxMsg::Error(L_CONFIG_EDITTPL_ERROR_NOTHEME);
 	header('Location: parametres_affichage.php');
 	exit;
@@ -57,7 +57,7 @@ function listFolderFiles($dir, $include, $root=''){
 	}
 	return $content;
 }
-$root = PLX_ROOT.$plxAdmin->aConf['racine_themes'].$style;
+$root = $plxAdmin->aConf['racine_themes'].$style;
 $aTemplates=listFolderFiles($root, array('.php','.css','.htm','.html','.txt','.js','.xml'), $root);
 
 # On récupère le contenu du fichier template
@@ -78,7 +78,7 @@ include __DIR__ .'/top.php';
 		<h2><?php echo L_CONFIG_EDITTPL_TITLE ?> &laquo;<?php echo plxUtils::strCheck($style) ?>&raquo;</h2>
 		<p><?php echo L_CONFIG_VIEW_PLUXML_RESSOURCES ?></p>
 		<?php echo plxToken::getTokenPostMethod() ?>
-		<?php plxUtils::printSelectDir('template', $tpl, PLX_ROOT.$plxAdmin->aConf['racine_themes'].$style, 'no-margin', false) ?>
+		<?php plxUtils::printSelectDir('template', $tpl, $plxAdmin->aConf['racine_themes'].$style, 'no-margin', false) ?>
 		<input name="load" type="submit" value="<?php echo L_CONFIG_EDITTPL_LOAD ?>" />
 		<span class="sml-hide med-show">&nbsp;&nbsp;&nbsp;</span>
 		<input name="submit" type="submit" value="<?php echo L_SAVE_FILE ?>" />

--- a/core/admin/parametres_help.php
+++ b/core/admin/parametres_help.php
@@ -25,7 +25,7 @@ switch($help) {
 		$back_to = 'parametres_plugins.php';
 		break;
 	case 'theme':
-		$filename = realpath(PLX_ROOT.$plxAdmin->aConf['racine_themes'].$page.'/lang/'.$plxAdmin->aConf['default_lang'].'-help.php');
+		$filename = realpath($plxAdmin->aConf['racine_themes'].$page.'/lang/'.$plxAdmin->aConf['default_lang'].'-help.php');
 		$back_to_title = L_BACK_TO_THEMES;
 		$back_to = 'parametres_themes.php';
 		break;

--- a/core/admin/parametres_infos.php
+++ b/core/admin/parametres_infos.php
@@ -47,12 +47,12 @@ if($emailBuild) {
 	<?php plxUtils::testWrite(PLX_ROOT) ?>
 	<?php plxUtils::testWrite(PLX_CONFIG_PATH); ?>
 	<?php plxUtils::testWrite(PLX_CONFIG_PATH.'plugins/'); ?>
-	<?php plxUtils::testWrite(PLX_ROOT.$plxAdmin->aConf['racine_articles']); ?>
-	<?php plxUtils::testWrite(PLX_ROOT.$plxAdmin->aConf['racine_commentaires']); ?>
-	<?php plxUtils::testWrite(PLX_ROOT.$plxAdmin->aConf['racine_statiques']); ?>
-	<?php plxUtils::testWrite(PLX_ROOT.$plxAdmin->aConf['medias']); ?>
-	<?php plxUtils::testWrite(PLX_ROOT.$plxAdmin->aConf['racine_plugins']); ?>
-	<?php plxUtils::testWrite(PLX_ROOT.$plxAdmin->aConf['racine_themes']); ?>
+	<?php plxUtils::testWrite($plxAdmin->aConf['racine_articles']); ?>
+	<?php plxUtils::testWrite($plxAdmin->aConf['racine_commentaires']); ?>
+	<?php plxUtils::testWrite($plxAdmin->aConf['racine_statiques']); ?>
+	<?php plxUtils::testWrite($plxAdmin->aConf['medias']); ?>
+	<?php plxUtils::testWrite($plxAdmin->aConf['racine_plugins']); ?>
+	<?php plxUtils::testWrite($plxAdmin->aConf['racine_themes']); ?>
 	<?php plxUtils::testModReWrite() ?>
 	<?php plxUtils::testLibGD() ?>
 	<?php plxUtils::testLibXml() ?>

--- a/core/admin/parametres_infos.php
+++ b/core/admin/parametres_infos.php
@@ -45,8 +45,8 @@ if($emailBuild) {
 </ul>
 <ul class="unstyled-list">
 	<?php plxUtils::testWrite(PLX_ROOT) ?>
-	<?php plxUtils::testWrite(PLX_ROOT.PLX_CONFIG_PATH); ?>
-	<?php plxUtils::testWrite(PLX_ROOT.PLX_CONFIG_PATH.'plugins/'); ?>
+	<?php plxUtils::testWrite(PLX_CONFIG_PATH); ?>
+	<?php plxUtils::testWrite(PLX_CONFIG_PATH.'plugins/'); ?>
 	<?php plxUtils::testWrite(PLX_ROOT.$plxAdmin->aConf['racine_articles']); ?>
 	<?php plxUtils::testWrite(PLX_ROOT.$plxAdmin->aConf['racine_commentaires']); ?>
 	<?php plxUtils::testWrite(PLX_ROOT.$plxAdmin->aConf['racine_statiques']); ?>

--- a/core/admin/parametres_plugincss.php
+++ b/core/admin/parametres_plugincss.php
@@ -18,9 +18,9 @@ $plugin = isset($_GET['p'])?urldecode($_GET['p']):'';
 $plugin = plxUtils::nullbyteRemove($plugin);
 
 # chargement du fichier css du plugin pour le frontend
-$file_frontend = PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.basename($plugin).'.site.css';
+$file_frontend = PLX_CONFIG_PATH.'plugins/'.basename($plugin).'.site.css';
 # chargement du fichier css du plugin pour le backend
-$file_backend = PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.basename($plugin).'.admin.css';
+$file_backend = PLX_CONFIG_PATH.'plugins/'.basename($plugin).'.admin.css';
 
 # Traitement du formulaire: sauvegarde du code css et regénération du cache
 if(isset($_POST['submit'])) {

--- a/core/admin/parametres_plugins.php
+++ b/core/admin/parametres_plugins.php
@@ -58,7 +58,7 @@ function pluginsList($plugins, $defaultLang, $type) {
 				# plugin infos
 				$output .= '<td class="wrap">';
 					# message d'alerte si plugin non configuré
-					if($type AND file_exists(PLX_PLUGINS.$plugName.'/config.php') AND !file_exists(PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.$plugName.'.xml')) $output .= '<span style="margin-top:5px" class="alert red float-right">'.L_PLUGIN_NO_CONFIG.'</span>';
+					if($type AND file_exists(PLX_PLUGINS.$plugName.'/config.php') AND !file_exists(PLX_CONFIG_PATH.'plugins/'.$plugName.'.xml')) $output .= '<span style="margin-top:5px" class="alert red float-right">'.L_PLUGIN_NO_CONFIG.'</span>';
 					# title + version
 					$output .= '<strong>'.plxUtils::strCheck($plugInstance->getInfo('title')).'</strong> - '.L_PLUGINS_VERSION.' <strong>'.plxUtils::strCheck($plugInstance->getInfo('version')).'</strong>';
 					# date

--- a/core/admin/parametres_themes.php
+++ b/core/admin/parametres_themes.php
@@ -93,7 +93,7 @@ class plxThemes {
 # On inclut le header
 include __DIR__ .'/top.php';
 
-$plxThemes = new plxThemes(PLX_ROOT.$plxAdmin->aConf['racine_themes'], $plxAdmin->aConf['style']);
+$plxThemes = new plxThemes($plxAdmin->aConf['racine_themes'], $plxAdmin->aConf['style']);
 
 ?>
 <form action="parametres_themes.php" method="post" id="form_settings">
@@ -141,7 +141,7 @@ $plxThemes = new plxThemes(PLX_ROOT.$plxAdmin->aConf['racine_themes'], $plxAdmin
 								echo '<strong>'.$theme.'</strong>';
 							}
 							# lien aide
-							if(is_file(PLX_ROOT.$plxAdmin->aConf['racine_themes'].$theme.'/lang/'.$plxAdmin->aConf['default_lang'].'-help.php'))
+							if(is_file($plxAdmin->aConf['racine_themes'].$theme.'/lang/'.$plxAdmin->aConf['default_lang'].'-help.php'))
 								echo '<a title="'.L_HELP_TITLE.'" href="parametres_help.php?help=theme&amp;page='.urlencode($theme).'">'.L_HELP.'</a>';
 
 						echo '</td>';

--- a/core/admin/statique.php
+++ b/core/admin/statique.php
@@ -57,7 +57,7 @@ if(!empty($_POST) AND isset($plxAdmin->aStats[$_POST['id']])) {
 
 # On récupère les templates des pages statiques
 $aTemplates = array();
-$files = plxGlob::getInstance(PLX_ROOT.$plxAdmin->aConf['racine_themes'].$plxAdmin->aConf['style']);
+$files = plxGlob::getInstance($plxAdmin->aConf['racine_themes'].$plxAdmin->aConf['style']);
 if ($array = $files->query('/^static(-[a-z0-9-_]+)?.php$/')) {
 	foreach($array as $k=>$v)
 		$aTemplates[$v] = $v;

--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -131,7 +131,7 @@ class plxAdmin extends plxMotor {
 			$newpath=trim($content['config_path']);
 			if($newpath!=PLX_CONFIG_PATH) {
 				# relocalisation du dossier de configuration de PluXml
-				if(!rename(PLX_ROOT.PLX_CONFIG_PATH,PLX_ROOT.$newpath))
+				if(!rename(PLX_CONFIG_PATH,PLX_ROOT.$newpath))
 					return plxMsg::Error(sprintf(L_WRITE_NOT_ACCESS, $newpath));
 				# mise à jour du fichier de configuration config.php
 				if(!plxUtils::write("<?php define('PLX_CONFIG_PATH', '".$newpath."') ?>", PLX_ROOT.'config.php'))

--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -580,7 +580,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 						}
 						$filenameArray[1] = implode(",", $filenameArrayCat);
 						$filenameNew = implode(".", $filenameArray);
-						rename(PLX_ROOT.$this->aConf['racine_articles'].$filename, PLX_ROOT.$this->aConf['racine_articles'].$filenameNew);
+						rename($this->aConf['racine_articles'].$filename, $this->aConf['racine_articles'].$filenameNew);
 					}
 				}
 				unset($this->aCats[$cat_id]);
@@ -729,7 +729,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 		# suppression
 		if(!empty($content['selection']) AND $content['selection']=='delete' AND isset($content['idStatic']) AND empty($content['update'])) {
 			foreach($content['idStatic'] as $static_id) {
-				$filename = PLX_ROOT.$this->aConf['racine_statiques'].$static_id.'.'.$this->aStats[$static_id]['url'].'.php';
+				$filename = $this->aConf['racine_statiques'].$static_id.'.'.$this->aStats[$static_id]['url'].'.php';
 				if(is_file($filename)) unlink($filename);
 				# si la page statique supprimée est la page d'accueil on met à jour le parametre
 				if($static_id==$this->aConf['homestatic']) {
@@ -750,8 +750,8 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 					if($stat_url=='') $stat_url = L_DEFAULT_NEW_STATIC_URL;
 					# On vérifie si on a besoin de renommer le fichier de la page statique
 					if(isset($this->aStats[$static_id]) AND $this->aStats[$static_id]['url']!=$stat_url) {
-						$oldfilename = PLX_ROOT.$this->aConf['racine_statiques'].$static_id.'.'.$this->aStats[$static_id]['url'].'.php';
-						$newfilename = PLX_ROOT.$this->aConf['racine_statiques'].$static_id.'.'.$stat_url.'.php';
+						$oldfilename = $this->aConf['racine_statiques'].$static_id.'.'.$this->aStats[$static_id]['url'].'.php';
+						$newfilename = $this->aConf['racine_statiques'].$static_id.'.'.$stat_url.'.php';
 						if(is_file($oldfilename)) rename($oldfilename, $newfilename);
 					}
 					$this->aStats[$static_id]['group'] = trim($content[$static_id.'_group']);
@@ -833,7 +833,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 	public function getFileStatique($num) {
 
 		# Emplacement de la page
-		$filename = PLX_ROOT.$this->aConf['racine_statiques'].$num.'.'.$this->aStats[ $num ]['url'].'.php';
+		$filename = $this->aConf['racine_statiques'].$num.'.'.$this->aStats[ $num ]['url'].'.php';
 		if(file_exists($filename) AND filesize($filename) > 0) {
 			if($f = fopen($filename, 'r')) {
 				$content = fread($f, filesize($filename));
@@ -869,7 +869,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 		eval($this->plxPlugins->callHook('plxAdminEditStatique'));
 		if($this->editStatiques(null,true)) {
 			# Génération du nom du fichier de la page statique
-			$filename = PLX_ROOT.$this->aConf['racine_statiques'].$content['id'].'.'.$this->aStats[ $content['id'] ]['url'].'.php';
+			$filename = $this->aConf['racine_statiques'].$content['id'].'.'.$this->aStats[ $content['id'] ]['url'].'.php';
 			# On écrit le fichier
 			if(plxUtils::write($content['content'],$filename))
 				return plxMsg::Info(L_SAVE_SUCCESSFUL);
@@ -973,12 +973,12 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 		$time = $content['date_publication_year'].$content['date_publication_month'].$content['date_publication_day'].substr(str_replace(':','',$content['date_publication_time']),0,4);
 		if(!preg_match('/^[0-9]{12}$/',$time)) $time = date('YmdHi'); # Check de la date au cas ou...
 		if(empty($content['catId'])) $content['catId']=array('000'); # Catégorie non classée
-		$filename = PLX_ROOT.$this->aConf['racine_articles'].$id.'.'.implode(',', $content['catId']).'.'.trim($content['author']).'.'.$time.'.'.$content['url'].'.xml';
+		$filename = $this->aConf['racine_articles'].$id.'.'.implode(',', $content['catId']).'.'.trim($content['author']).'.'.$time.'.'.$content['url'].'.xml';
 		# On va mettre à jour notre fichier
 		if(plxUtils::write($xml,$filename)) {
 			# suppression ancien fichier si nécessaire
 			if($oldArt) {
-				$oldfilename = PLX_ROOT.$this->aConf['racine_articles'].$oldArt['0'];
+				$oldfilename = $this->aConf['racine_articles'].$oldArt['0'];
 				if($oldfilename!=$filename AND file_exists($oldfilename))
 					unlink($oldfilename);
 			}
@@ -1010,15 +1010,15 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 		$resDelArt = $resDelCom = true;
 		# Suppression de l'article
 		if($globArt = $this->plxGlob_arts->query('/^'.$id.'.(.*).xml$/')) {
-			unlink(PLX_ROOT.$this->aConf['racine_articles'].$globArt['0']);
-			$resDelArt = !file_exists(PLX_ROOT.$this->aConf['racine_articles'].$globArt['0']);
+			unlink($this->aConf['racine_articles'].$globArt['0']);
+			$resDelArt = !file_exists($this->aConf['racine_articles'].$globArt['0']);
 		}
 		# Suppression des commentaires
 		if($globComs = $this->plxGlob_coms->query('/^_?'.str_replace('_','',$id).'.(.*).xml$/')) {
 			$nb_coms=sizeof($globComs);
 			for($i=0; $i<$nb_coms; $i++) {
-				unlink(PLX_ROOT.$this->aConf['racine_commentaires'].$globComs[$i]);
-				$resDelCom = (!file_exists(PLX_ROOT.$this->aConf['racine_commentaires'].$globComs[$i]) AND $resDelCom);
+				unlink($this->aConf['racine_commentaires'].$globComs[$i]);
+				$resDelCom = (!file_exists($this->aConf['racine_commentaires'].$globComs[$i]) AND $resDelCom);
 			}
 		}
 
@@ -1084,7 +1084,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 		$comment=array();
 		# Génération du nom du fichier
 		$comment['filename'] = $id.'.xml';
-		if(!file_exists(PLX_ROOT.$this->aConf['racine_commentaires'].$comment['filename'])) # Commentaire inexistant
+		if(!file_exists($this->aConf['racine_commentaires'].$comment['filename'])) # Commentaire inexistant
 			return plxMsg::Error(L_ERR_UNKNOWN_COMMENT);
 		# Contrôle des saisies
 		if(trim($content['mail'])!='' AND !plxUtils::checkMail(trim($content['mail'])))
@@ -1092,7 +1092,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 		if(trim($content['site'])!='' AND !plxUtils::checkSite($content['site']))
 			return plxMsg::Error(L_ERR_INVALID_SITE);
 		# On récupère les infos du commentaire
-		$com = $this->parseCommentaire(PLX_ROOT.$this->aConf['racine_commentaires'].$comment['filename']);
+		$com = $this->parseCommentaire($this->aConf['racine_commentaires'].$comment['filename']);
 		# Formatage des données
 		if($com['type'] != 'admin') {
 			$comment['author'] = plxUtils::strCheck(trim($content['author']));
@@ -1134,7 +1134,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 	public function delCommentaire($id) {
 
 		# Génération du nom du fichier
-		$filename = PLX_ROOT.$this->aConf['racine_commentaires'].$id.'.xml';
+		$filename = $this->aConf['racine_commentaires'].$id.'.xml';
 		# Suppression du commentaire
 		if(file_exists($filename)) {
 			unlink($filename);
@@ -1159,7 +1159,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 		$capture = '';
 
 		# Génération du nom du fichier
-		$oldfilename = PLX_ROOT.$this->aConf['racine_commentaires'].$id.'.xml';
+		$oldfilename = $this->aConf['racine_commentaires'].$id.'.xml';
 		if(!file_exists($oldfilename)) # Commentaire inexistant
 			return plxMsg::Error(L_ERR_UNKNOWN_COMMENT);
 		# Modérer ou valider ?
@@ -1169,7 +1169,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 		if($mod=='offline')
 			$id = '_'.$id;
 		# Génération du nouveau nom de fichier
-		$newfilename = PLX_ROOT.$this->aConf['racine_commentaires'].$id.'.xml';
+		$newfilename = $this->aConf['racine_commentaires'].$id.'.xml';
 		# On renomme le fichier
 		@rename($oldfilename,$newfilename);
 		# Contrôle

--- a/core/lib/class.plx.feed.php
+++ b/core/lib/class.plx.feed.php
@@ -52,8 +52,8 @@ class plxFeed extends plxMotor {
 		# Hook plugins
 		eval($this->plxPlugins->callHook('plxFeedConstructLoadPlugins'));
 		# Traitement sur les répertoires des articles et des commentaires
-		$this->plxGlob_arts = plxGlob::getInstance(PLX_ROOT.$this->aConf['racine_articles'],false,true,'arts');
-		$this->plxGlob_coms = plxGlob::getInstance(PLX_ROOT.$this->aConf['racine_commentaires']);
+		$this->plxGlob_arts = plxGlob::getInstance($this->aConf['racine_articles'],false,true,'arts');
+		$this->plxGlob_coms = plxGlob::getInstance($this->aConf['racine_commentaires']);
 		# Récupération des données dans les autres fichiers xml
 		$this->getCategories(path('XMLFILE_CATEGORIES'));
 		$this->getUsers(path('XMLFILE_USERS'));

--- a/core/lib/class.plx.glob.php
+++ b/core/lib/class.plx.glob.php
@@ -46,10 +46,9 @@ class plxGlob {
 	 * @return	plxGlob			return une instance de la classe plxGlob
 	 * @author	Stephane F
 	 **/
-	public static function getInstance($dir,$rep=false,$onlyfilename=true,$type=''){
-		$basename = str_replace(PLX_ROOT, '', $dir);
+	public static function getInstance($basename,$rep=false,$onlyfilename=true,$type=''){
 		if (!isset(self::$instance[$basename]))
-			self::$instance[$basename] = new plxGlob($dir,$rep,$onlyfilename,$type);
+			self::$instance[$basename] = new plxGlob($basename,$rep,$onlyfilename,$type);
 		return self::$instance[$basename];
 	}
 

--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -10,8 +10,7 @@
 include_once PLX_CORE.'lib/class.plx.template.php';
 
 class plxMotor {
-	const PLX_TEMPLATES = PLX_CORE . 'templates/';
-	const PLX_TEMPLATES_DATA = PLX_ROOT . 'data/templates/';
+	const PLX_TEMPLATES_DATA = PLX_DATA_PATH.'templates/';
 
 	public $get = false; # Donnees variable GET
 	public $racine = false; # Url de PluXml
@@ -102,8 +101,8 @@ class plxMotor {
 		# Hook plugins
 		eval($this->plxPlugins->callHook('plxMotorConstructLoadPlugins'));
 		# Traitement sur les répertoires des articles et des commentaires
-		$this->plxGlob_arts = plxGlob::getInstance(PLX_ROOT.$this->aConf['racine_articles'],false,true,'arts');
-		$this->plxGlob_coms = plxGlob::getInstance(PLX_ROOT.$this->aConf['racine_commentaires']);
+		$this->plxGlob_arts = plxGlob::getInstance($this->aConf['racine_articles'],false,true,'arts');
+		$this->plxGlob_coms = plxGlob::getInstance($this->aConf['racine_commentaires']);
 		# Récupération des données dans les autres fichiers xml
 		$this->getCategories(path('XMLFILE_CATEGORIES'));
 		$this->getStatiques(path('XMLFILE_STATICS'));
@@ -114,7 +113,7 @@ class plxMotor {
 		# Hook plugins
 		eval($this->plxPlugins->callHook('plxMotorConstruct'));
 		# Get templates from core/templates and data/templates
-		$this->getTemplates(self::PLX_TEMPLATES);
+		$this->getTemplates(self::PLX_TEMPLATES_PATH);
 		$this->getTemplates(self::PLX_TEMPLATES_DATA);
 	}
 
@@ -393,7 +392,7 @@ class plxMotor {
 		$this->aConf['hometemplate'] = isset($this->aConf['hometemplate']) ? $this->aConf['hometemplate'] : 'home.php';
 		$this->aConf['custom_admincss_file'] = plxUtils::getValue($this->aConf['custom_admincss_file']);
 		$this->aConf['medias'] = isset($this->aConf['medias']) ? $this->aConf['medias'] : 'data/images/';
-		if(!defined('PLX_PLUGINS')) define('PLX_PLUGINS', PLX_ROOT.$this->aConf['racine_plugins']);
+		if(!defined('PLX_PLUGINS')) define('PLX_PLUGINS', $this->aConf['racine_plugins']);
 
 	}
 
@@ -529,7 +528,7 @@ class plxMotor {
 				$date_update = plxUtils::getValue($iTags['date_update'][$i]);
 				$this->aStats[$number]['date_update']=plxUtils::getValue($values[$date_update]['value']);
 				# On verifie que la page statique existe bien
-				$file = PLX_ROOT.$this->aConf['racine_statiques'].$number.'.'.$attributes['url'].'.php';
+				$file = $this->aConf['racine_statiques'].$number.'.'.$attributes['url'].'.php';
 				# On test si le fichier est lisible
 				$this->aStats[$number]['readable'] = (is_readable($file) ? 1 : 0);
 				# Hook plugins
@@ -640,7 +639,7 @@ class plxMotor {
 		if($aFiles = $this->plxGlob_arts->query($this->motif,'art',$this->tri,$start,$this->bypage,$publi)) {
 			# on mémorise le nombre total d'articles trouvés
 			foreach($aFiles as $k=>$v) # On parcourt tous les fichiers
-				$array[$k] = $this->parseArticle(PLX_ROOT.$this->aConf['racine_articles'].$v);
+				$array[$k] = $this->parseArticle($this->aConf['racine_articles'].$v);
 			# On stocke les enregistrements dans un objet plxRecord
 			$this->plxRecord_arts = new plxRecord($array);
 			return true;
@@ -838,7 +837,7 @@ class plxMotor {
 		$aFiles = $this->plxGlob_coms->query($motif,'com',$ordre,$start,$limite,$publi);
 		if($aFiles) { # On a des fichiers
 			foreach($aFiles as $k=>$v)
-				$array[$k] = $this->parseCommentaire(PLX_ROOT.$this->aConf['racine_commentaires'].$v);
+				$array[$k] = $this->parseCommentaire($this->aConf['racine_commentaires'].$v);
 
 			# hiérarchisation et indentation des commentaires seulement sur les écrans requis
 			if( !(defined('plxAdmin::PLX_ADMIN') OR defined('plxFeed::PLX_FEED')) OR preg_match('/comment_new/',basename($_SERVER['SCRIPT_NAME']))) {
@@ -863,7 +862,7 @@ class plxMotor {
 	 public function nextIdArtComment($idArt) {
 
 		$ret = '0';
-		if($dh = opendir(PLX_ROOT.$this->aConf['racine_commentaires'])) {
+		if($dh = opendir($this->aConf['racine_commentaires'])) {
 			$Idxs = array();
 			while(false !== ($file = readdir($dh))) {
 				if(preg_match("/_?".$idArt.".[0-9]+-([0-9]+).xml/", $file, $capture)) {
@@ -961,7 +960,7 @@ class plxMotor {
 		eval($this->plxPlugins->callHook('plxMotorAddCommentaireXml'));
 		$xml .= "</comment>\n";
 		# On ecrit ce contenu dans notre fichier XML
-		return plxUtils::write($xml, PLX_ROOT.$this->aConf['racine_commentaires'].$content['filename']);
+		return plxUtils::write($xml, $this->aConf['racine_commentaires'].$content['filename']);
 	}
 
 	/**
@@ -1030,11 +1029,11 @@ class plxMotor {
 	public function sendTelechargement($cible) {
 
 		# On décrypte le nom du fichier
-		$file = PLX_ROOT.$this->aConf['medias'].plxEncrypt::decryptId($cible);
+		$file = $this->aConf['medias'].plxEncrypt::decryptId($cible);
 		# Hook plugins
 		if(eval($this->plxPlugins->callHook('plxMotorSendDownload'))) return;
 		# On lance le téléchargement et on check le répertoire medias
-		if(file_exists($file) AND preg_match('#^'.str_replace('\\', '/', realpath(PLX_ROOT.$this->aConf['medias']).'#'), str_replace('\\', '/', realpath($file)))) {
+		if(file_exists($file) AND preg_match('#^'.str_replace('\\', '/', realpath($this->aConf['medias']).'#'), str_replace('\\', '/', realpath($file)))) {
 			header('Content-Description: File Transfer');
 			header('Content-Type: application/download');
 			header('Content-Disposition: attachment; filename='.basename($file));

--- a/core/lib/class.plx.plugins.php
+++ b/core/lib/class.plx.plugins.php
@@ -215,14 +215,14 @@ class plxPlugins {
 						foreach($content['chkAction'] as $idx => $plugName) {
 							if($this->deleteDir(realpath(PLX_PLUGINS.$plugName))) {
 								# suppression fichier de config du plugin
-								if(is_file(PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.$plugName.'.xml'))
-									unlink(PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.$plugName.'.xml');
+								if(is_file(PLX_CONFIG_PATH.'plugins/'.$plugName.'.xml'))
+									unlink(PLX_CONFIG_PATH.'plugins/'.$plugName.'.xml');
 								# suppression fichier site.css du plugin
-								if(is_file(PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.$plugName.'.site.css'))
-									unlink(PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.$plugName.'.site.css');
+								if(is_file(PLX_CONFIG_PATH.'plugins/'.$plugName.'.site.css'))
+									unlink(PLX_CONFIG_PATH.'plugins/'.$plugName.'.site.css');
 								# suppression fichier admin.css du plugin
-								if(is_file(PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.$plugName.'.admin.css'))
-									unlink(PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.$plugName.'.admin.css');
+								if(is_file(PLX_CONFIG_PATH.'plugins/'.$plugName.'.admin.css'))
+									unlink(PLX_CONFIG_PATH.'plugins/'.$plugName.'.admin.css');
 								unset($this->aPlugins[$plugName]);
 							} else {
 								plxMsg::Error(L_PLUGINS_DELETE_ERROR." (".$plugName.")");
@@ -308,7 +308,7 @@ class plxPlugins {
 		if(!preg_match('@\.css$@', $type)) $type .= '.css';
 		foreach(array_keys($this->aPlugins) as $plugName) {
 			$filesList = array(
-				PLX_ROOT.PLX_CONFIG_PATH."plugins/$plugName.$type",
+				PLX_CONFIG_PATH."plugins/$plugName.$type",
 				PLX_PLUGINS."$plugName/css/$type"
 			);
 			foreach($filesList as $filename) {
@@ -363,7 +363,7 @@ class plxPlugin {
 			'dir' 			=> PLX_PLUGINS,
 			'name' 			=> $plugName,
 			'filename'		=> PLX_PLUGINS.$plugName.'/'.$plugName.'.php',
-			'parameters.xml'=> PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.$plugName.'.xml',
+			'parameters.xml'=> PLX_CONFIG_PATH.'plugins/'.$plugName.'.xml',
 			'infos.xml'		=> PLX_PLUGINS.$plugName.'/infos.xml'
 		);
 		$this->loadParams();

--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -40,7 +40,7 @@ class plxShow {
 		$this->plxMotor = plxMotor::getInstance();
 
 		# Chargement du fichier de lang du theme
-		$langfile = PLX_ROOT.$this->plxMotor->aConf['racine_themes'].$this->plxMotor->style.'/lang/'.$this->plxMotor->aConf['default_lang'].'.php';
+		$langfile = $this->plxMotor->aConf['racine_themes'].$this->plxMotor->style.'/lang/'.$this->plxMotor->aConf['default_lang'].'.php';
 		if(is_file($langfile)) {
 			include $langfile;
 			$this->lang = $LANG; # $LANG = tableau contenant les traductions présentes dans le fichier de langue
@@ -486,7 +486,7 @@ class plxShow {
 				),
 				array(
 					$img_url, # #img_url
-					(file_exists(PLX_ROOT.$img_thumb)) ? $this->plxMotor->urlRewrite($img_thumb) : $img_url, # #img_thumb_url
+					(file_exists($img_thumb)) ? $this->plxMotor->urlRewrite($img_thumb) : $img_url, # #img_thumb_url
 					plxUtils::strCheck(plxUtils::getValue($this->plxMotor->aCats[$this->plxMotor->cible]['thumbnail_title'])), # #img_title
 					plxUtils::strCheck(plxUtils::getValue($this->plxMotor->aCats[$this->plxMotor->cible]['thumbnail_alt'])) # #img_alt
 				),
@@ -577,7 +577,7 @@ class plxShow {
 				),
 				array(
 					$img_url, # #img_url
-					(file_exists(PLX_ROOT.$img_thumb)) ? $this->plxMotor->urlRewrite($img_thumb) : $img_url, # #img_thumb_url
+					(file_exists($img_thumb)) ? $this->plxMotor->urlRewrite($img_thumb) : $img_url, # #img_thumb_url
 					plxUtils::strCheck($this->plxMotor->plxRecord_arts->f('thumbnail_title')), # #img_title
 					$this->plxMotor->plxRecord_arts->f('thumbnail_alt') # #img_alt
 				),
@@ -995,7 +995,7 @@ class plxShow {
 		$plxGlob_arts = clone $this->plxMotor->plxGlob_arts;
 		if($aFiles = $plxGlob_arts->query($motif,'art',$sort,0,$max,'before')) {
 			foreach($aFiles as $v) { # On parcourt tous les fichiers
-				$art = $this->plxMotor->parseArticle(PLX_ROOT.$this->plxMotor->aConf['racine_articles'].$v);
+				$art = $this->plxMotor->parseArticle($this->plxMotor->aConf['racine_articles'].$v);
 				$num = intval($art['numero']);
 				$date = $art['date'];
 				if(($this->plxMotor->mode == 'article') AND ($art['numero'] == $this->plxMotor->cible))
@@ -1305,7 +1305,7 @@ class plxShow {
 			foreach($aFiles as $v) {
 				# On filtre si le commentaire appartient à un article d'une catégorie inactive
 				if(isset($this->plxMotor->activeArts[substr($v,0,4)])) {
-					$com = $this->plxMotor->parseCommentaire(PLX_ROOT.$this->plxMotor->aConf['racine_commentaires'].$v);
+					$com = $this->plxMotor->parseCommentaire($this->plxMotor->aConf['racine_commentaires'].$v);
 					$artInfo = $this->plxMotor->artInfoFromFilename($this->plxMotor->plxGlob_arts->aFiles[$com['article']]);
 					if($artInfo['artDate']<=$datetime) { # on ne prends que les commentaires pour les articles publiés
 						if(empty($cat_ids) OR preg_match('/('.$cat_ids.')/', $artInfo['catId'])) {
@@ -1334,7 +1334,7 @@ class plxShow {
 								}
 								else {
 									if($file = $this->plxMotor->plxGlob_arts->query('/^'.$com['article'].'.(.*).xml$/')) {
-										$art = $this->plxMotor->parseArticle(PLX_ROOT.$this->plxMotor->aConf['racine_articles'].$file[0]);
+										$art = $this->plxMotor->parseArticle($this->plxMotor->aConf['racine_articles'].$file[0]);
 										$aComArtTitles[$com['article']] = $art_title = $art['title'];
 										$row = str_replace('#com_art_title',$art_title,$row);
 									}
@@ -1513,7 +1513,7 @@ class plxShow {
 	public function staticDate($format='#day #num_day #month #num_year(4)') {
 
 		# On genere le nom du fichier dont on veux récupérer la date
-		$file = PLX_ROOT.$this->plxMotor->aConf['racine_statiques'].$this->plxMotor->cible;
+		$file = $this->plxMotor->aConf['racine_statiques'].$this->plxMotor->cible;
 		$file .= '.'.$this->plxMotor->aStats[ $this->plxMotor->cible ]['url'].'.php';
 		# Test de l'existence du fichier
 		if(!file_exists($file)) return;
@@ -1558,7 +1558,7 @@ class plxShow {
 		# On va verifier que la page a inclure est lisible
 		if($this->plxMotor->aStats[ $this->plxMotor->cible ]['readable'] == 1) {
 			# On genere le nom du fichier a inclure
-			$file = PLX_ROOT.$this->plxMotor->aConf['racine_statiques'].$this->plxMotor->cible;
+			$file = $this->plxMotor->aConf['racine_statiques'].$this->plxMotor->cible;
 			$file .= '.'.$this->plxMotor->aStats[ $this->plxMotor->cible ]['url'].'.php';
 			# Inclusion du fichier
 			ob_start();
@@ -1584,7 +1584,7 @@ class plxShow {
 		# Hook Plugins
 		if(eval($this->plxMotor->plxPlugins->callHook('plxShowStaticInclude'))) return ;
 		# On génère un nouvel objet plxGlob
-		$plxGlob_stats = plxGlob::getInstance(PLX_ROOT.$this->plxMotor->aConf['racine_statiques']);
+		$plxGlob_stats = plxGlob::getInstance($this->plxMotor->aConf['racine_statiques']);
 		if(is_numeric($id)) # inclusion à partir de l'id de la page
 			$regx = '/^'.str_pad($id,3,'0',STR_PAD_LEFT).'.[a-z0-9-]+.php$/';
 		else { # inclusion à partir du titre de la page
@@ -1595,7 +1595,7 @@ class plxShow {
 			# on récupère l'id de la page pour tester si elle est active
 			if(preg_match('/^([0-9]{3}).(.*).php$/', $files[0], $c)) {
 				if($this->plxMotor->aStats[$c[1]]['active'])
-					include PLX_ROOT.$this->plxMotor->aConf['racine_statiques'].$files[0];
+					include $this->plxMotor->aConf['racine_statiques'].$files[0];
 			}
 		}
 	}

--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -1484,9 +1484,9 @@ EOT;
 	public static function printLinkCss($file, $admin=false) {
 
 		$plxMotor = ($admin) ? false : plxMotor::getinstance();
-		if(is_file(PLX_ROOT.$file)) {
-			$href = ($admin) ? PLX_ROOT.$file : $plxMotor->urlRewrite($file);
-			$href .= '?d='.base_convert(filemtime(PLX_ROOT.$file) & 4194303, 10, 36); # 4194303 === 2 puissance 22 - 1; base_convert(4194303, 10, 16) -> 3fffff; => 48,54 jours
+		if(is_file($file)) {
+			$href = ($admin) ? $file : $plxMotor->urlRewrite($file);
+			$href .= '?d='.base_convert(filemtime($file) & 4194303, 10, 36); # 4194303 === 2 puissance 22 - 1; base_convert(4194303, 10, 16) -> 3fffff; => 48,54 jours
 			echo <<< LINK
 	<link rel="stylesheet" type="text/css" href="$href" media="screen" />\n
 LINK;

--- a/core/lib/config.php
+++ b/core/lib/config.php
@@ -26,12 +26,12 @@ function getMicrotime() {
 define('PLX_MICROTIME', getMicrotime());
 
 $CONSTS = array(
-	'XMLFILE_PARAMETERS'	=> PLX_ROOT.PLX_CONFIG_PATH.'parametres.xml',
-	'XMLFILE_CATEGORIES'	=> PLX_ROOT.PLX_CONFIG_PATH.'categories.xml',
-	'XMLFILE_STATICS'		=> PLX_ROOT.PLX_CONFIG_PATH.'statiques.xml',
-	'XMLFILE_USERS'			=> PLX_ROOT.PLX_CONFIG_PATH.'users.xml',
-	'XMLFILE_PLUGINS'		=> PLX_ROOT.PLX_CONFIG_PATH.'plugins.xml',
-	'XMLFILE_TAGS'			=> PLX_ROOT.PLX_CONFIG_PATH.'tags.xml',
+	'XMLFILE_PARAMETERS'	=> PLX_CONFIG_PATH.'parametres.xml',
+	'XMLFILE_CATEGORIES'	=> PLX_CONFIG_PATH.'categories.xml',
+	'XMLFILE_STATICS'		=> PLX_CONFIG_PATH.'statiques.xml',
+	'XMLFILE_USERS'			=> PLX_CONFIG_PATH.'users.xml',
+	'XMLFILE_PLUGINS'		=> PLX_CONFIG_PATH.'plugins.xml',
+	'XMLFILE_TAGS'			=> PLX_CONFIG_PATH.'tags.xml',
 );
 
 # Définition de l'encodage => PLX_CHARSET : UTF-8 (conseillé) ou ISO-8859-1

--- a/index.php
+++ b/index.php
@@ -62,16 +62,16 @@ $plxShow = plxShow::getInstance();
 eval($plxMotor->plxPlugins->callHook('IndexBegin')); # Hook Plugins
 
 # Traitements du thème
-if(empty($plxMotor->style) or !is_dir(PLX_ROOT.$plxMotor->aConf['racine_themes'].$plxMotor->style)) {
+if(empty($plxMotor->style) or !is_dir($plxMotor->aConf['racine_themes'].$plxMotor->style)) {
 	header('Content-Type: text/plain; charset='.PLX_CHARSET);
-	echo L_ERR_THEME_NOTFOUND.' ('.PLX_ROOT.$plxMotor->aConf['racine_themes'].$plxMotor->style.') !';
+	echo L_ERR_THEME_NOTFOUND.' ('.$plxMotor->aConf['racine_themes'].$plxMotor->style.') !';
 	exit;
 }
 
 # On teste si le template existe
-if(!file_exists(PLX_ROOT.$plxMotor->aConf['racine_themes'].$plxMotor->style.'/'.$plxMotor->template)) {
+if(!file_exists($plxMotor->aConf['racine_themes'].$plxMotor->style.'/'.$plxMotor->template)) {
 	header('Content-Type: text/plain; charset='.PLX_CHARSET);
-	echo L_ERR_FILE_NOTFOUND.' ('.PLX_ROOT.$plxMotor->aConf['racine_themes'].$plxMotor->style.'/'.$plxMotor->template.') !';
+	echo L_ERR_FILE_NOTFOUND.' ('.$plxMotor->aConf['racine_themes'].$plxMotor->style.'/'.$plxMotor->template.') !';
 	exit;
 }
 
@@ -83,7 +83,7 @@ ob_implicit_flush(0);
 header('Content-Type: text/html; charset='.PLX_CHARSET);
 
 # Insertion du template
-include(PLX_ROOT.$plxMotor->aConf['racine_themes'].$plxMotor->style.'/'.$plxMotor->template);
+include($plxMotor->aConf['racine_themes'].$plxMotor->style.'/'.$plxMotor->template);
 
 # Récupération de la bufférisation
 $output = ob_get_clean();

--- a/install.php
+++ b/install.php
@@ -2,15 +2,15 @@
 const PLX_ROOT = './';
 const PLX_CORE = PLX_ROOT .'core/';
 
+include PLX_ROOT.'config.php';
+include PLX_CORE.'lib/config.php';
+
 const PLX_DATA_ARTICLES_PATH = PLX_DATA_PATH.'articles/';
 const PLX_DATA_STATIQUES_PATH = PLX_DATA_PATH.'statiques/';
 const PLX_DATA_COMMENTAIRES_PATH = PLX_DATA_PATH.'commentaires/';
 const PLX_DATA_PLUGINS_PATH = PLX_DATA_PATH.'plugins/';
 const PLX_DATA_MEDIAS_PATH = PLX_DATA_PATH.'medias/';
 const PLX_DATA_TEMPLATES_PATH = PLX_DATA_PATH.'templates/';
-
-include PLX_ROOT.'config.php';
-include PLX_CORE.'lib/config.php';
 
 # On démarre la session
 session_set_cookie_params(0, "/", $_SERVER['SERVER_NAME'], isset($_SERVER["HTTPS"]), true);

--- a/install.php
+++ b/install.php
@@ -466,8 +466,8 @@ EOT;
 						<li><?= $_SERVER['SERVER_SOFTWARE']; ?></li>
 <?php } ?>
 						<?php plxUtils::testWrite(PLX_ROOT) ?>
-						<?php plxUtils::testWrite(PLX_ROOT.PLX_CONFIG_PATH) ?>
-						<?php plxUtils::testWrite(PLX_ROOT.PLX_CONFIG_PATH.'plugins/') ?>
+						<?php plxUtils::testWrite(PLX_CONFIG_PATH) ?>
+						<?php plxUtils::testWrite(PLX_CONFIG_PATH.'plugins/') ?>
 						<?php plxUtils::testWrite(PLX_DATA_ARTICLES_PATH) ?>
 						<?php plxUtils::testWrite(PLX_DATA_COMMENTAIRES_PATH) ?>
 						<?php plxUtils::testWrite(PLX_DATA_STATIQUES_PATH) ?>

--- a/install.php
+++ b/install.php
@@ -2,16 +2,12 @@
 const PLX_ROOT = './';
 const PLX_CORE = PLX_ROOT .'core/';
 
-const PLX_DATA_PATH = PLX_ROOT.'data/';
 const PLX_DATA_ARTICLES_PATH = PLX_DATA_PATH.'articles/';
 const PLX_DATA_STATIQUES_PATH = PLX_DATA_PATH.'statiques/';
 const PLX_DATA_COMMENTAIRES_PATH = PLX_DATA_PATH.'commentaires/';
 const PLX_DATA_PLUGINS_PATH = PLX_DATA_PATH.'plugins/';
 const PLX_DATA_MEDIAS_PATH = PLX_DATA_PATH.'medias/';
 const PLX_DATA_TEMPLATES_PATH = PLX_DATA_PATH.'templates/';
-
-const PLX_PLUGINS_PATH = PLX_ROOT.'plugins/';
-const PLX_THEMES_PATH = PLX_ROOT.'themes/';
 
 include PLX_ROOT.'config.php';
 include PLX_CORE.'lib/config.php';

--- a/sitemap.php
+++ b/sitemap.php
@@ -91,7 +91,7 @@ if($aFiles = $plxMotor->plxGlob_arts->query('/^\d{4}.(?:\d|home|,)*(?:'.$plxMoto
 	$plxRecord_arts = false;
 	$array=array();
 	foreach($aFiles as $k=>$v) { # On parcourt tous les fichiers
-		$array[ $k ] = $plxMotor->parseArticle(PLX_ROOT.$plxMotor->aConf['racine_articles'].$v);
+		$array[ $k ] = $plxMotor->parseArticle($plxMotor->aConf['racine_articles'].$v);
 	}
 	# On stocke les enregistrements dans un objet plxRecord
 	$plxRecord_arts = new plxRecord($array);


### PR DESCRIPTION
Suite à mon message du forum, je propose les modifications légères suivantes (cf. code) : 

1. Déplacer PLX_DATA_PATH dans le config.php afin que PLX_CONFIG_PATH puisse en profiter.
2. Déplacer également PLX_THEMES_PATH et PLX_PLUGINS_PATH afin que tous les chemins puissent être modifiés au même endroit.

Désormais, si on souhaite placer les répertoires DATA, PLUGINS, et THEMES ailleurs dans l'arborescence de son système, il suffit de modifier le config.php.