### PR TITLE
Optimisation plxToken::getTokenPostMethod() et plxCapcha

### DIFF
--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -882,14 +882,20 @@ class plxMotor {
 	 * @param	artId	identifiant de l'article en question
 	 * @param	content	tableau contenant les valeurs du nouveau commentaire
 	 * @return	string
-	 * @author	Florent MONTHEL, Stéphane F
+	 * @author	Florent MONTHEL, Stéphane F, J.P. Pourrez
 	 **/
-	public function newCommentaire($artId,$content) {
+	public function newCommentaire($artId, $content) {
 
 		# Hook plugins
 		if(eval($this->plxPlugins->callHook('plxMotorNewCommentaire'))) return;
 
-		if(strtolower($_SERVER['REQUEST_METHOD'])!= 'post' OR $this->aConf['capcha'] AND (!isset($_SESSION["capcha_token"]) OR !isset($_POST['capcha_token']) OR ($_SESSION["capcha_token"]!=$_POST['capcha_token']))) {
+		if(
+			!empty($this->aConf['capcha']) AND (
+				empty($_SESSION['capcha_token']) OR
+				empty($_POST['capcha_token']) or
+				($_SESSION['capcha_token'] != $_POST['capcha_token'])
+			)
+		) {
 			return L_NEWCOMMENT_ERR_ANTISPAM;
 		}
 

--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -1658,7 +1658,9 @@ class plxShow {
 		# Hook Plugins
 		if(eval($this->plxMotor->plxPlugins->callHook('plxShowCapchaQ'))) return;
 		echo $this->plxMotor->plxCapcha->q();
-		echo '<input type="hidden" name="capcha_token" value="'.$_SESSION['capcha_token'].'" />';
+?>
+		<input type="hidden" name="capcha_token" value="<?= $_SESSION['capcha_token'] ?>" />
+<?php
 	}
 
 	/**

--- a/core/lib/class.plx.token.php
+++ b/core/lib/class.plx.token.php
@@ -7,6 +7,7 @@
  **/
 class plxToken {
 	const TEMPLATE = 'abcdefghijklmnpqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+	const TEMPLATE_LENGTH = 61; // strlen(self::TEMPLATE);
 	const LIFETIME = 3600; // seconds
 
 	/**
@@ -16,13 +17,11 @@ class plxToken {
 	 * @author	Stephane F, J.P. Pourrez
 	 **/
 	public static function getTokenPostMethod($length=32, $html=true) {
-		$range = strlen(plxToken::TEMPLATE);
-		$result = array();
-		mt_srand((float)microtime() * 1000000);
-		for($i=0; $i<$length; $i++) {
-			$result[] = self::TEMPLATE[mt_rand() % $range];
-		}
-		$token = implode('', $result);
+		$token = substr(
+			str_shuffle(self::TEMPLATE),
+			mt_rand(0, self::TEMPLATE_LENGTH - $length),
+			$length
+		);
 		$_SESSION['formtoken'][$token] = time();
 		return ($html) ? '<input name="token" value="'.$token.'" type="hidden" />' : $token;
 	}
@@ -45,7 +44,7 @@ class plxToken {
 				die('Security error : invalid or expired token');
 			}
 			unset($_SESSION['formtoken'][$_POST['token']]);
-			// cleanup old tokens 
+			// cleanup old tokens
 			if(!empty($_SESSION['formtoken'])) {
 				foreach($_SESSION['formtoken'] as $token=>$lifetime) {
 					if($lifetime < $limit) {


### PR DESCRIPTION
Simplification pour la génération d'une chaine de caractères aléatoire basée sur la fonction str_shuffle()  de PHP et mt_rand(). 
Il n'y a plus besoin d'utiliser une boucle for.
Donc, c'est plus rapide.