### PR TITLE
Remplacer multiples str_replace par strtr

### DIFF
--- a/core/lib/class.plx.date.php
+++ b/core/lib/class.plx.date.php
@@ -80,29 +80,26 @@ class plxDate {
 	 **/
 	public static function formatDate($date, $format='#num_day/#num_month/#num_year(4)') {
 
-		# On decoupe notre date
-		$year4 = substr($date, 0, 4);
-		$year2 = substr($date, 2, 2);
 		$month = substr($date, 4, 2);
-		$day = substr($date, 6, 2);
 		$day_num = date('w',mktime(0,0,0,intval($month),intval($day),intval($year4)));
 		$hour = substr($date,8,2);
 		$minute = substr($date,10,2);
 
 		# On retourne notre date au format humain
-		$format = str_replace('#time', $hour.':'.$minute, $format);
-		$format = str_replace('#minute', $minute, $format);
-		$format = str_replace('#hour', $hour, $format);
-		$format = str_replace('#day', plxDate::getCalendar('day', $day_num), $format);
-		$format = str_replace('#short_month', plxDate::getCalendar('short_month', $month), $format);
-		$format = str_replace('#month', plxDate::getCalendar('month', $month), $format);
-		$format = str_replace('#num_day(1)', intval($day), $format);
-		$format = str_replace('#num_day(2)', $day, $format);
-		$format = str_replace('#num_day', $day, $format);
-		$format = str_replace('#num_month', $month, $format);
-		$format = str_replace('#num_year(2)', $year2 , $format);
-		$format = str_replace('#num_year(4)', $year4 , $format);
-		return $format;
+		return strtr($format, array(
+			'#time'			=> $hour.':' . $minute,
+			'#minute'		=> $minute,
+			'#hour'			=> $hour,
+			'#day'			=> plxDate::getCalendar('day', $day_num),
+			'#short_month'	=> plxDate::getCalendar('short_month', $month),
+			'#month'		=> plxDate::getCalendar('month', $month),
+			'#num_day(1)'	=> intval(substr($date, 6, 2)),
+			'#num_day(2)'	=> substr($date, 6, 2),
+			'#num_day'		=> substr($date, 6, 2),
+			'#num_month'	=> $month,
+			'#num_year(2)'	=> substr($date, 2, 2),
+			'#num_year(4)'	=> substr($date, 0, 4)
+		));
 	}
 
 	/**

--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -335,12 +335,13 @@ class plxShow {
 
 		# Si on a la variable extra, on affiche un lien vers la page d'accueil (avec $extra comme nom)
 		if($extra != '') {
-			$name = str_replace('#cat_id','cat-home',$format);
-			$name = str_replace('#cat_url',$this->plxMotor->urlRewrite(),$name);
-			$name = str_replace('#cat_name',plxUtils::strCheck($extra),$name);
-			$name = str_replace('#cat_status',($this->catId()=='home'?'active':'noactive'), $name);
-			$name = str_replace('#art_nb','',$name);
-			echo $name;
+			echo strtr($format, array(
+				'#cat_id'		=> 'cat-home',
+				'#cat_url'		=> $this->plxMotor->urlRewrite(),
+				'#cat_name'		=> plxUtils::strCheck($extra),
+				'#cat_status'	=> ($this->catId() == 'home') ? 'active' : 'noactive',
+				'#art_nb'		=> ''
+			));
 		}
 
 		# On verifie qu'il y a des categories
@@ -357,16 +358,17 @@ class plxShow {
 				if($in AND !$ex) {
 					if(($v['articles']>0 OR $this->plxMotor->aConf['display_empty_cat']) AND ($v['menu']=='oui') AND $v['active']) { # On a des articles
 						# On modifie nos motifs
-						$name = str_replace('#cat_id','cat-'.intval($k),$format);
-						$name = str_replace('#cat_url',$this->plxMotor->urlRewrite('?categorie'.intval($k).'/'.$v['url']),$name);
-						$name = str_replace('#cat_name',plxUtils::strCheck($v['name']),$name);
-						$name = str_replace('#cat_status',($this->catId()==intval($k)?'active':'noactive'), $name);
-						$name = str_replace('#cat_description',plxUtils::strCheck($v['description']),$name);
-						$name = str_replace('#art_nb',$v['articles'],$name);
-						echo $name;
+						echo strtr($format, array(
+							'#cat_id'			=> 'cat-' . intval($k),
+							'#cat_url'			=> $this->plxMotor->urlRewrite('?categorie'.intval($k).'/'.$v['url']),
+							'#cat_name'			=> plxUtils::strCheck($v['name']),
+							'#cat_status'		=> ($this->catId() == intval($k)) ? 'active' : 'noactive',
+							'#cat_description'	=> plxUtils::strCheck($v['description']),
+							'#art_nb'			=> $v['articles']
+						));
 					}
 				}
-			} # Fin du while
+			} # Fin de foreach
 		}
 	}
 
@@ -477,21 +479,12 @@ class plxShow {
 		if(!empty($filename)) {
 			$img_url = $this->plxMotor->urlRewrite($filename);
 			$img_thumb = plxUtils::thumbName($filename);
-			$result = str_replace(
-				array(
-					'#img_url',
-					'#img_thumb_url',
-					'#img_title',
-					'#img_alt'
-				),
-				array(
-					$img_url, # #img_url
-					(file_exists(PLX_ROOT.$img_thumb)) ? $this->plxMotor->urlRewrite($img_thumb) : $img_url, # #img_thumb_url
-					plxUtils::strCheck(plxUtils::getValue($this->plxMotor->aCats[$this->plxMotor->cible]['thumbnail_title'])), # #img_title
-					plxUtils::strCheck(plxUtils::getValue($this->plxMotor->aCats[$this->plxMotor->cible]['thumbnail_alt'])) # #img_alt
-				),
-				$format
-			);
+			$result = strtr($format, array(
+				'#img_url'			=> $img_url,
+				'#img_thumb_url'	=> (file_exists(PLX_ROOT.$img_thumb)) ? $this->plxMotor->urlRewrite($img_thumb) : $img_url,
+				'#img_title'		=> plxUtils::strCheck($this->plxMotor->aCats[$this->plxMotor->cible]['thumbnail_title']),
+				'#img_alt'			=> plxUtils::strCheck($this->plxMotor->aCats[$this->plxMotor->cible]['thumbnail_alt'])
+			));
 
 			if($echo)
 				echo $result;
@@ -568,21 +561,12 @@ class plxShow {
 		if(!empty($filename)) {
 			$img_url = $this->plxMotor->urlRewrite($filename);
 			$img_thumb = plxUtils::thumbName($filename);
-			$result = str_replace(
-				array(
-					'#img_url',
-					'#img_thumb_url',
-					'#img_title',
-					'#img_alt'
-				),
-				array(
-					$img_url, # #img_url
-					(file_exists(PLX_ROOT.$img_thumb)) ? $this->plxMotor->urlRewrite($img_thumb) : $img_url, # #img_thumb_url
-					plxUtils::strCheck($this->plxMotor->plxRecord_arts->f('thumbnail_title')), # #img_title
-					$this->plxMotor->plxRecord_arts->f('thumbnail_alt') # #img_alt
-				),
-				$format
-			);
+			$result = strtr($format, array(
+				'#img_url'			=> $img_url,
+				'#img_thumb_url'	=> (file_exists(PLX_ROOT.$img_thumb)) ? $this->plxMotor->urlRewrite($img_thumb) : $img_url,
+				'#img_title'		=> plxUtils::strCheck($this->plxMotor->plxRecord_arts->f('thumbnail_title')),
+				'#img_alt'			=> $this->plxMotor->plxRecord_arts->f('thumbnail_alt')
+			));
 			if($echo)
 				echo $result;
 			else
@@ -636,9 +620,10 @@ class plxShow {
 
 		$infos = plxUtils::getValue($this->plxMotor->aUsers[$this->plxMotor->plxRecord_arts->f('author')]['infos']);
 		if(trim($infos)!='') {
-			$txt = str_replace('#art_authorinfos', $infos, $format);
-			$txt = str_replace('#art_author', $this->artAuthor(false), $txt);
-			echo $txt;
+			echo strtr($format, array(
+				'#art_authorinfos'	=> $infos,
+				'#art_author'		=> $this->artAuthor(false)
+			));
 		}
 	}
 
@@ -736,12 +721,12 @@ class plxShow {
 		if(!empty($taglist)) {
 			$tags = array_map('trim', explode(',', $taglist));
 			foreach($tags as $idx => $tag) {
-				$t = plxUtils::urlify($tag);
-				$name = str_replace('#tag_url',$this->plxMotor->urlRewrite('?tag/'.$t),$format);
-				$name = str_replace('#tag_name',plxUtils::strCheck($tag),$name);
-				$name = str_replace('#tag_status',(($this->plxMotor->mode=='tags' AND $this->plxMotor->cible==$t)?'active':'noactive'), $name);
-				echo $name;
-				if ($idx!=sizeof($tags)-1) echo $separator.' ';
+				echo strtr($format, array(
+					'#tag_url'		=> $this->plxMotor->urlRewrite('?tag/' . plxUtils::urlify($tag)),
+					'#tag_name'		=> plxUtils::strCheck($tag),
+					'#tag_status'	=> ($this->plxMotor->mode=='tags' AND $this->plxMotor->cible==$t) ? 'active' : 'noactive'
+				));
+				if ($idx!=sizeof($tags)-1) echo $separator . ' ';
 			}
 		}
 		else echo L_NONE1;
@@ -765,9 +750,10 @@ class plxShow {
 				$title = plxUtils::strCheck($this->plxMotor->plxRecord_arts->f('title'));
 				$url = $this->plxMotor->plxRecord_arts->f('url');
 				# Formatage de l'affichage
-				$row = str_replace("#art_url", $this->plxMotor->urlRewrite('?article'.$id.'/'.$url), $format);
-				$row = str_replace("#art_title", $title, $row);
-				echo $row;
+				echo strtr($format, array(
+					'#art_url'		=> $this->plxMotor->urlRewrite('?article'.$id.'/'.$url),
+					'#art_title'	=> $title
+				));
 			}
 		}
 	}
@@ -863,17 +849,20 @@ class plxShow {
 				# Fil Rss des articles d'une catégorie
 				$id = str_pad ( $categorie, 3, '0', STR_PAD_LEFT );
 				if (isset ( $this->plxMotor->aCats [$id] )) {
-					$result = str_replace('#feedUrl', $this->plxMotor->urlRewrite('feed.php?rss/categorie'.$categorie.'/'.$this->plxMotor->aCats[$id]['url']), $format);
-					$result = str_replace('#feedTitle', L_ARTFEED_RSS_CATEGORY, $result);
-					$result = str_replace('#feedName', L_ARTFEED_RSS_CATEGORY, $result);
+					echo strtr($format,array(
+						'#feedUrl'		=> $this->plxMotor->urlRewrite('feed.php?rss/categorie'.$categorie.'/'.$this->plxMotor->aCats[$id]['url']),
+						'#feedTitle'	=> L_ARTFEED_RSS_CATEGORY,
+						'#feedName'		=> L_ARTFEED_RSS_CATEGORY
+					));
 				}
 			} else {
 				# Fil Rss des articles
-				$result = str_replace('#feedUrl', $this->plxMotor->urlRewrite('feed.php?rss'), $format);
-				$result = str_replace('#feedTitle', L_ARTFEED_RSS, $result);
-				$result = str_replace('#feedName', L_ARTFEED_RSS, $result);
+					echo strtr($format,array(
+						'#feedUrl'		=> $this->plxMotor->urlRewrite('feed.php?rss'),
+						'#feedTitle'	=> L_ARTFEED_RSS,
+						'#feedName'		=> L_ARTFEED_RSS
+					));
 			}
-			echo $result;
 		}
 	}
 
@@ -998,10 +987,7 @@ class plxShow {
 				$art = $this->plxMotor->parseArticle(PLX_ROOT.$this->plxMotor->aConf['racine_articles'].$v);
 				$num = intval($art['numero']);
 				$date = $art['date'];
-				if(($this->plxMotor->mode == 'article') AND ($art['numero'] == $this->plxMotor->cible))
-					$status = 'active';
-				else
-					$status = 'noactive';
+				$status = (($this->plxMotor->mode == 'article') AND ($art['numero'] == $this->plxMotor->cible)) ? 'active' : 'noactive';
 
 				# Mise en forme de la liste des catégories
 				$catList = array();
@@ -1017,30 +1003,33 @@ class plxShow {
 				}
 
 				# On modifie nos motifs
-				$row = str_replace('#art_id',$num,$format);
-				$row = str_replace('#cat_list', implode(', ',$catList),$row);
-				$row = str_replace('#art_url',$this->plxMotor->urlRewrite('?article'.$num.'/'.$art['url']),$row);
-				$row = str_replace('#art_status',$status,$row);
 				$author = plxUtils::getValue($this->plxMotor->aUsers[$art['author']]['name']);
-				$row = str_replace('#art_author',plxUtils::strCheck($author),$row);
-				$row = str_replace('#art_title',plxUtils::strCheck($art['title']),$row);
-				$strlength = preg_match('/#art_chapo\(([0-9]+)\)/',$row,$capture) ? $capture[1] : '100';
-				$chapo = plxUtils::truncate($art['chapo'],$strlength,$ending,true,true);
-				$row = str_replace('#art_chapo('.$strlength.')','#art_chapo',$row);
-				$row = str_replace('#art_chapo',$chapo,$row);
-				$strlength = preg_match('/#art_content\(([0-9]+)\)/',$row,$capture) ? $capture[1] : '100';
-				$content = plxUtils::truncate($art['content'],$strlength,$ending,true,true);
-				$row = str_replace('#art_content('.$strlength.')','#art_content',$row);
-				$row = str_replace('#art_content',$content,$row);
-				$row = str_replace('#art_date',plxDate::formatDate($date,'#num_day/#num_month/#num_year(4)'),$row);
-				$row = str_replace('#art_hour',plxDate::formatDate($date,'#hour:#minute'),$row);
-				$row = str_replace('#art_time',plxDate::formatDate($date,'#time'),$row);
-				$row = plxDate::formatDate($date,$row);
-				$row = str_replace('#art_nbcoms',$art['nb_com'],$row);
-				$row = str_replace('#art_thumbnail', '<img class="art_thumbnail" src="#img_url" alt="#img_alt" title="#img_title" />',$row);
-				$row = str_replace('#img_url',$this->plxMotor->urlRewrite($art['thumbnail']),$row);
-				$row = str_replace('#img_title',$art['thumbnail_title'],$row);
-				$row = str_replace('#img_alt',$art['thumbnail_alt'],$row);
+				$l1 = preg_match('/#art_chapo\(([0-9]+)\)/',$row,$capture) ? $capture[1] : '100';
+				$chapo = plxUtils::truncate($art['chapo'],$l1,$ending,true,true);
+				$strlength2 = preg_match('/#art_content\(([0-9]+)\)/',$row,$capture) ? $capture[1] : '100';
+
+				$row = strtr($format, array(
+					'#art_id'				=> $num,
+					'#cat_list'				=> implode(', ', $catList),
+					'#art_url'				=> $this->plxMotor->urlRewrite('?article' . $num . '/' . $art['url']),
+					'#art_status'			=> $status,
+					'#art_author'			=> plxUtils::strCheck($author),
+					'#art_title'			=> plxUtils::strCheck($art['title']),
+					'#art_chapo('.$l1.')'	=> '#art_chapo',
+					'#art_chapo'			=> $chapo,
+					'#art_content('.$l2.')'	=>'#art_content',
+					'#art_content'			=> plxUtils::truncate($art['content'],$l2,$ending,true,true),
+					'#art_date'				=> plxDate::formatDate($date,'#num_day/#num_month/#num_year(4)'),
+					'#art_hour'				=> plxDate::formatDate($date,'#hour:#minute'),
+					'#art_time'				=> plxDate::formatDate($date,'#time'),
+
+					'#art_nbcoms'			=> $art['nb_com'],
+					'#art_thumbnail'		=> '<img class="art_thumbnail" src="#img_url" alt="#img_alt" title="#img_title" />',
+					'#img_url'				=> $this->plxMotor->urlRewrite($art['thumbnail']),
+					'#img_title'			=> $art['thumbnail_title'],
+					'#img_alt'				=> $art['thumbnail_alt']
+				));
+				$row = plxDate::formatDate($date,$row); # ????
 
 				# Hook plugin
 				eval($this->plxMotor->plxPlugins->callHook('plxShowLastArtListContent'));
@@ -1214,9 +1203,10 @@ class plxShow {
 				default:
 					$color = 'red';
 			}
-			$row = str_replace('#com_message', $_SESSION['msgcom'], $format);
-			$row = str_replace('#com_class', 'alert '.$color, $row);
-			echo $row;
+			echo strtr($format, array(
+				'#com_message'	=> $_SESSION['msgcom'],
+				'#com_class'	=> 'alert ' . $color
+			));
 			unset($_SESSION['msgcom']);
 			return true;
 		}
@@ -1258,15 +1248,18 @@ class plxShow {
 
 		if ($this->plxMotor->aConf ['enable_rss']) {
 			if ($article != '' and is_numeric ( $article )) { # Fil Rss des commentaires d'un article
-				$result = str_replace('#feedUrl', $this->plxMotor->urlRewrite('feed.php?rss/commentaires/article'.$article), $format);
-				$result = str_replace('#feedTitle', L_COMFEED_RSS_ARTICLE, $result);
-				$result = str_replace('#feedName', L_COMFEED_RSS_ARTICLE, $result);
+				echo strtr($format, array(
+					'#feedUrl'		=> $this->plxMotor->urlRewrite('feed.php?rss/commentaires/article'.$article),
+					'#feedTitle'	=> L_COMFEED_RSS_ARTICLE,
+					'#feedName'		=> L_COMFEED_RSS_ARTICLE
+				));
 			} else { # Fil Rss des commentaires global
-				$result = str_replace('#feedUrl', $this->plxMotor->urlRewrite ( 'feed.php?rss/commentaires' ), $format);
-				$result = str_replace('#feedTitle', L_COMFEED_RSS, $result);
-				$result = str_replace('#feedName', L_COMFEED_RSS, $result);
+				echo strtr($format, array(
+					'#feedUrl'		=> $this->plxMotor->urlRewrite ( 'feed.php?rss/commentaires' ),
+					'#feedTitle'	=> L_COMFEED_RSS,
+					'#feedName'		=> L_COMFEED_RSS
+				));
 			}
-			echo $result;
 		}
 	}
 
@@ -1307,25 +1300,27 @@ class plxShow {
 				if(isset($this->plxMotor->activeArts[substr($v,0,4)])) {
 					$com = $this->plxMotor->parseCommentaire(PLX_ROOT.$this->plxMotor->aConf['racine_commentaires'].$v);
 					$artInfo = $this->plxMotor->artInfoFromFilename($this->plxMotor->plxGlob_arts->aFiles[$com['article']]);
-					if($artInfo['artDate']<=$datetime) { # on ne prends que les commentaires pour les articles publiés
+					if($artInfo['artDate']<=$datetime) { # on ne prend que les commentaires pour les articles publiés
 						if(empty($cat_ids) OR preg_match('/('.$cat_ids.')/', $artInfo['catId'])) {
 							$url = '?article'.intval($com['article']).'/'.$artInfo['artUrl'].'#c'.$com['article'].'-'.$com['index'];
 							$date = $com['date'];
 							$content = strip_tags($com['content']);
-							# On modifie nos motifs
-							$row = str_replace('L_SAID', L_SAID, $format);
-							$row = str_replace('#com_id',$com['index'],$row);
-							$row = str_replace('#com_url',$this->plxMotor->urlRewrite($url),$row);
-							$row = str_replace('#com_author',$com['author'],$row);
 							while(preg_match('/#com_content\(([0-9]+)\)/',$row,$capture)) {
 								if($com['author'] == 'admin')
 									$row = str_replace('#com_content('.$capture[1].')',plxUtils::strCut($content,$capture[1]),$row);
 								else
 									$row = str_replace('#com_content('.$capture[1].')',plxUtils::strCheck(plxUtils::strCut(plxUtils::strRevCheck($content),$capture[1])),$row);
 							}
-							$row = str_replace('#com_content',$content,$row);
-							$row = str_replace('#com_date',plxDate::formatDate($date,'#num_day/#num_month/#num_year(4)'),$row);
-							$row = str_replace('#com_hour',plxDate::formatDate($date,'#time'),$row);
+							# On modifie nos motifs
+							$row = strtr($format, array(
+								'L_SAID'		=> L_SAID,
+								'#com_id'		=> $com['index'],
+								'#com_url'		=> $this->plxMotor->urlRewrite($url),
+								'#com_author'	=> $com['author'],
+								'#com_content'	=> $content,
+								'#com_date'		=> plxDate::formatDate($date,'#num_day/#num_month/#num_year(4)'),
+								'#com_hour'		=> plxDate::formatDate($date,'#time')
+							));
 							$row = plxDate::formatDate($date,$row);
 							# récupération du titre de l'article
 							if($isComArtTitle) {
@@ -1340,7 +1335,7 @@ class plxShow {
 									}
 								}
 							}
-							# On genère notre ligne
+							# On génère notre ligne
 							echo $row;
 							$count++;
 						}
@@ -1369,27 +1364,31 @@ class plxShow {
 		$home = ((empty($this->plxMotor->get) OR preg_match('/^page[0-9]*/',$this->plxMotor->get)) AND basename($_SERVER['SCRIPT_NAME'])=="index.php");
 		# Si on a la variable extra, on affiche un lien vers la page d'accueil (avec $extra comme nom)
 		if($extra != '') {
-			$stat = str_replace('#static_id','static-home',$format);
-			$stat = str_replace('#static_class','static menu',$stat);
-			$stat = str_replace('#static_url',$this->plxMotor->urlRewrite(),$stat);
-			$stat = str_replace('#static_name',plxUtils::strCheck($extra),$stat);
-			$stat = str_replace('#static_status',($home==true?"active":"noactive"), $stat);
-			$menus[][] = $stat;
+			$menus[][] = strtr($format, array(
+				'#static_id'		=> 'static-home',
+				'#static_class'		=> 'static menu',
+				'#static_url'		=> $this->plxMotor->urlRewrite(),
+				'#static_name'		=> plxUtils::strCheck($extra),
+				'#static_status'	=> ($home) ? 'active' : 'noactive'
+			));
 		}
 		$group_active = "";
 		if($this->plxMotor->aStats) {
 			foreach($this->plxMotor->aStats as $k=>$v) {
 				if($v['active'] == 1 AND $v['menu'] == 'oui') { # La page  est bien active et dispo ds le menu
-					$stat = str_replace('#static_id','static-'.intval($k),$format);
-					$stat = str_replace('#static_class','static menu',$stat);
 					if($v['url'][0]=='?') # url interne commençant par ?
-						$stat = str_replace('#static_url',$this->plxMotor->urlRewrite($v['url']),$stat);
+						$url = $this->plxMotor->urlRewrite($v['url']);
 					elseif(plxUtils::checkSite($v['url'],false)) # url externe en http ou autre
-						$stat = str_replace('#static_url',$v['url'],$stat);
+						$url = $v['url'];
 					else # url page statique
-						$stat = str_replace('#static_url',$this->plxMotor->urlRewrite('?static'.intval($k).'/'.$v['url']),$stat);
-					$stat = str_replace('#static_name',plxUtils::strCheck($v['name']),$stat);
-					$stat = str_replace('#static_status',($this->staticId()==intval($k)?'active':'noactive'), $stat);
+						$url = $this->plxMotor->urlRewrite('?static'.intval($k).'/'.$v['url']);
+					$stat = strtr($format, array(
+						'#static_id'		=> 'static-' . intval($k),
+						'#static_class'		=> 'static menu',
+						'#static_name'		=> plxUtils::strCheck($v['name']),
+						'#static_status'	=> ($this->staticId()==intval($k)) ? 'active' : 'noactive',
+						'#static_url'		=> $url
+					));
 					if($v['group']=='')
 						$menus[][] = $stat;
 					else
@@ -1402,16 +1401,14 @@ class plxShow {
 		if($menublog) {
 			if($this->plxMotor->aConf['homestatic']!='' AND isset($this->plxMotor->aStats[$this->plxMotor->aConf['homestatic']])) {
 				if($this->plxMotor->aStats[$this->plxMotor->aConf['homestatic']]['active']) {
-					$menu = str_replace('#static_id','static-blog',$format);
-					if ($this->plxMotor->get AND preg_match('/(blog|categorie|archives|tag|article)/', $_SERVER['QUERY_STRING'].$this->plxMotor->mode)) {
-						$menu = str_replace('#static_status','active',$menu);
-					} else {
-						$menu = str_replace('#static_status','noactive',$menu);
-					}
-					$menu = str_replace('#static_url', $this->plxMotor->urlRewrite('?blog'),$menu);
-					$menu = str_replace('#static_name',L_BLOG,$menu);
-					$menu = str_replace('#static_class','static menu',$menu);
-					array_splice($menus, (intval($menublog)-1), 0, array($menu));
+					$stat = strtr($format, array(
+						'#static_id'		=> 'static-blog',
+						'#static_status'	=> ($this->plxMotor->get AND preg_match('/(blog|categorie|archives|tag|article)/', $_SERVER['QUERY_STRING'].$this->plxMotor->mode)) ? 'active' : 'noactive',
+						'#static_url'		=> $this->plxMotor->urlRewrite('?blog'),
+						'#static_name'		=> L_PAGEBLOG_TITLE,
+						'#static_class'		=> 'static menu'
+					));
+					array_splice($menus, (intval($menublog)-1), 0, array($stat));
 				}
 			}
 		}
@@ -1423,13 +1420,15 @@ class plxShow {
 		if($menus) {
 			foreach($menus as $k=>$v) {
 				if(is_numeric($k)) {
-					echo "\n".(is_array($v) ? $v[0] : $v);
+					echo PHP_EOL . (is_array($v) ? $v[0] : $v);
 				}
 				else {
-					$group = str_replace('#group_id','static-group-'.plxUtils::urlify($k),$format_group);
-					$group = str_replace('#group_class','static group',$group);
-					$group = str_replace('#group_status',($group_active==$k?'active':'noactive'),$group);
-					$group = str_replace('#group_name',plxUtils::strCheck($k),$group);
+					$group = strtr($format_group, array(
+						'#group_id'		=> 'static-group-'.plxUtils::urlify($k),
+						'#group_class'	=> 'static group',
+						'#group_status'	=> ($group_active==$k?'active':'noactive'),
+						'#group_name'	=> plxUtils::strCheck($k)
+					));
 					echo "\n<li class=\"menu\">\n\t".$group."\n\t<ul id=\"static-".plxUtils::urlify($k)."\" class=\"sub-menu\">\t\t";
 					foreach($v as $kk => $vv) {
 						echo "\n\t\t".$vv;
@@ -1437,7 +1436,7 @@ class plxShow {
 					echo "\n\t</ul>\n</li>\n";
 				}
 			}
-			echo "\n";
+			echo PHP_EOL;
 		}
 
 	}
@@ -1726,10 +1725,11 @@ class plxShow {
 			if ($tag == '' and $this->plxMotor->mode == 'tags') {
 				$tag = $this->plxMotor->cible;
 			}
-			$result = str_replace('#feedUrl', $this->plxMotor->urlRewrite('feed.php?rss/tag/'.plxUtils::strCheck($tag)), $format);
-			$result = str_replace('#feedTitle', L_ARTFEED_RSS_TAG, $result);
-			$result = str_replace('#feedName', L_ARTFEED_RSS_TAG, $result);
-			echo $result;
+			echo strtr($format, array(
+				'#feedUrl'		=> $this->plxMotor->urlRewrite('feed.php?rss/tag/'.plxUtils::strCheck($tag)),
+				'#feedTitle'	=> L_ARTFEED_RSS_TAG,
+				'#feedName'		=> L_ARTFEED_RSS_TAG
+			));
 		}
 	}
 
@@ -1826,17 +1826,12 @@ class plxShow {
 			$id=0;
 			foreach($counters as $tag => $counter) {
 				$url = plxUtils::urlify($tag);
-				$status = 'noactive';
 				switch($mode) {
-					case 'article':
-						if(in_array($tag, $artTags)) {
-							$status = 'active';
-						}
-						break;
-					case 'tags':
-						$status = ($this->plxMotor->cible == $url) ? 'active' : 'noactive';
+					case 'article':	$status = (in_array($tag, $artTags)) ? 'active' : 'noactive'; break;
+					case 'tags':	$status = ($this->plxMotor->cible == $url) ? 'active' : 'noactive'; break;
+					default :		$status = '';
 				}
-				$replaces = array(
+				echo strtr($format, array(
 					'#tag_id'		=> 'tag-'.$id++,
 					'#tag_size'		=> 'tag-size-'.(1 + intval($counter / $max_value)), # taille des caractères
 					'#tag_count'	=> $counter,
@@ -1845,8 +1840,7 @@ class plxShow {
 					'#tag_url'		=> $this->plxMotor->urlRewrite('?tag/'.$url),
 					'#tag_name'		=> plxUtils::strCheck($tag),
 					'#tag_status'	=> $status
-				);
-				echo str_replace(array_keys($replaces), array_values($replaces), $format);
+				));
 			}
 		}
 	}


### PR DESCRIPTION
Une nouvelle fois, on privilégie l'emploi de strtr() à str_replace() pour des remplacements multiples.
C'est plus rapide et plus fiable.