### PR TITLE
plxAdmin::editConfiguration()

### DIFF
--- a/core/admin/get_oauth_token.php
+++ b/core/admin/get_oauth_token.php
@@ -122,7 +122,7 @@ if (!isset($_GET['code'])) {
     $tokenToStore['smtpOauth2_refreshToken'] = $token->getRefreshToken();
     // Store the token in the PluXMl configuration and redirect to the administration page
     if (!empty($tokenToStore)) {
-    	$plxAdmin->editConfiguration($plxAdmin->aConf, $tokenToStore);
+    	$plxAdmin->editConfiguration($tokenToStore);
     }
     header('Location: '.htmlentities($plxAdmin->aConf['racine'].'core/admin/parametres_avances.php'));
 }

--- a/core/admin/parametres_affichage.php
+++ b/core/admin/parametres_affichage.php
@@ -17,13 +17,14 @@ $plxAdmin->checkProfil(PROFIL_ADMIN);
 
 # On édite la configuration
 if(!empty($_POST)) {
-	$_POST['feed_footer']=$_POST['content'];
-	$_POST['images_l']=plxUtils::getValue($_POST['images_l'],800);
-	$_POST['images_h']=plxUtils::getValue($_POST['images_h'],600);
-	$_POST['miniatures_l']=plxUtils::getValue($_POST['miniatures_l'],200);
-	$_POST['miniatures_h']=plxUtils::getValue($_POST['miniatures_h'],100);
+	$_POST['feed_footer']	= $_POST['content'];
+	$_POST['images_l']		= plxUtils::getValue($_POST['images_l'], 800);
+	$_POST['images_h']		= plxUtils::getValue($_POST['images_h'], 600);
+	$_POST['miniatures_l']	= plxUtils::getValue($_POST['miniatures_l'], 200);
+	$_POST['miniatures_h']	= plxUtils::getValue($_POST['miniatures_h'], 100);
 	unset($_POST['content']);
-	$plxAdmin->editConfiguration($plxAdmin->aConf,$_POST);
+
+	$plxAdmin->editConfiguration($_POST);
 	header('Location: parametres_affichage.php');
 	exit;
 }

--- a/core/admin/parametres_avances.php
+++ b/core/admin/parametres_avances.php
@@ -16,8 +16,9 @@ $plxAdmin->checkProfil(PROFIL_ADMIN);
 
 # On édite la configuration
 if(!empty($_POST)) {
-	$plxAdmin->editConfiguration($plxAdmin->aConf,$_POST);
-	unset($_SESSION['medias']); # réinit de la variable de session medias (pour medias.php) au cas si changmt de chemin medias
+	$plxAdmin->editConfiguration($_POST);
+	# réinit de la variable de session medias (pour medias.php) au cas si changmt de chemin medias
+	unset($_SESSION['medias']);
 	header('Location: parametres_avances.php');
 	exit;
 }

--- a/core/admin/parametres_base.php
+++ b/core/admin/parametres_base.php
@@ -18,7 +18,7 @@ $plxAdmin->checkProfil(PROFIL_ADMIN);
 
 # On édite la configuration
 if(!empty($_POST)) {
-	$plxAdmin->editConfiguration($plxAdmin->aConf,$_POST);
+	$plxAdmin->editConfiguration($_POST);
 	header('Location: parametres_base.php');
 	exit;
 }
@@ -117,7 +117,7 @@ include __DIR__ .'/top.php';
 			<div class="col sml-12 med-7">
 				<?php plxUtils::printSelect('enable_rss',array('1'=>L_YES,'0'=>L_NO), $plxAdmin->aConf['enable_rss']); ?>
 			</div>
-		</div>		
+		</div>
 	</fieldset>
 	<?php eval($plxAdmin->plxPlugins->callHook('AdminSettingsBase')) # Hook Plugins ?>
 	<?php echo plxToken::getTokenPostMethod() ?>

--- a/core/admin/parametres_themes.php
+++ b/core/admin/parametres_themes.php
@@ -7,7 +7,7 @@
  * @author	Stephane F
  **/
 
-include __DIR__ .'/prepend.php';
+include __DIR__ . '/prepend.php';
 
 # Control du token du formulaire
 plxToken::validateFormToken($_POST);
@@ -17,7 +17,7 @@ $plxAdmin->checkProfil(PROFIL_ADMIN);
 
 # On édite la configuration
 if(!empty($_POST)) {
-	$plxAdmin->editConfiguration($plxAdmin->aConf,$_POST);
+	$plxAdmin->editConfiguration($_POST);
 	header('Location: parametres_themes.php');
 	exit;
 }

--- a/core/admin/statiques.php
+++ b/core/admin/statiques.php
@@ -20,10 +20,7 @@ $plxAdmin->checkProfil(PROFIL_MANAGER);
 
 # On édite les pages statiques
 if(!empty($_POST)) {
-	if(isset($_POST['homeStatic']))
-		$plxAdmin->editConfiguration($plxAdmin->aConf, array('homestatic'=>$_POST['homeStatic'][0]));
-	else
-		$plxAdmin->editConfiguration($plxAdmin->aConf, array('homestatic'=>''));
+	$plxAdmin->editConfiguration(!empty($_POST['homeStatic']) ? array('homestatic'=>$_POST['homeStatic'][0]) : array('homestatic'=>''));
 	$plxAdmin->editStatiques($_POST);
 	header('Location: statiques.php');
 	exit;


### PR DESCRIPTION
Inutile de passer $plxAdmin->aConf à la fonction plxAdmin::editConfiguration() !

Génére systématiquement le fichier .htaccess si urlrewrite activé ( isset() != !empty() )