### PR TITLE
update artThumbnail()

### DIFF
--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -555,19 +555,28 @@ class plxShow {
 	}
 
 	/**
-	 * Méthode qui affiche l'image d'accroche d'un article
+	 * Méthode qui affiche l'image d'accroche d'un article linké vers l'article (variable $type='link') ou vers l'image
 	 *
+	 * @param	type	type d'affichage : link => sous forme de lien
 	 * @param	format	format d'affichage (variables: #img_url, #img_thumb_url, #img_alt, #img_title)
 	 * @param	echo 	si à VRAI affichage à l'écran
 	 * @scope	home,categorie,article,tags,archives
-	 * @author	Stephane F
+	 * @author	Stephane F, Thatoo
 	 **/
-	public function artThumbnail($format='<a href="#img_url"><img class="art_thumbnail" src="#img_thumb_url" alt="#img_alt" title="#img_title" /></a>', $echo=true) {
+	public function artThumbnail($type='',$format='<a href="#img_url"><img class="art_thumbnail" src="#img_thumb_url" alt="#img_alt" title="#img_title" /></a>', $echo=true) {
 
 		$filename = trim($this->plxMotor->plxRecord_arts->f('thumbnail'));
 		if(!empty($filename)) {
 			$img_url = $this->plxMotor->urlRewrite($filename);
 			$img_thumb = plxUtils::thumbName($filename);
+			$id = intval($this->plxMotor->plxRecord_arts->f('numero'));
+			$url_art = $this->plxMotor->plxRecord_arts->f('url');
+			if($type == 'link') {
+				$url=$this->plxMotor->urlRewrite('?article'.$id.'/'.$url_art); #art_url
+				} else { # Type normal
+				$url=$img_url; # #img_url
+				}
+
 			$result = str_replace(
 				array(
 					'#img_url',
@@ -576,7 +585,7 @@ class plxShow {
 					'#img_alt'
 				),
 				array(
-					$img_url, # #img_url
+						$url,
 					(file_exists(PLX_ROOT.$img_thumb)) ? $this->plxMotor->urlRewrite($img_thumb) : $img_url, # #img_thumb_url
 					plxUtils::strCheck($this->plxMotor->plxRecord_arts->f('thumbnail_title')), # #img_title
 					$this->plxMotor->plxRecord_arts->f('thumbnail_alt') # #img_alt


### PR DESCRIPTION
Méthode qui affiche l'image d'accroche d'un article linké vers l'article (variable $type='link') ou vers l'image