### PR TITLE
Autorise les fontes natives lors du chargement

### DIFF
--- a/themes/defaut/css/theme.css
+++ b/themes/defaut/css/theme.css
@@ -21,6 +21,7 @@
 	url('../fonts/OpenSans-Regular-webfont.svg#open_sansregular') format('svg');
 	font-weight: normal;
 	font-style: normal;
+        font-display: swap;
 }
 body {
 	font-family: 'open_sansregular', sans-serif;


### PR DESCRIPTION
Autorise l'affichage temporaire avec les fontes natives, et les remplaces par celle du thème une fois chargée.
Accélère nettement l'affichage sur les connexions à faibles débits.
Et complètement transparent pour PluXML.