### PR TITLE
Fix longueur du titre de la page

### DIFF
--- a/themes/defaut/header.php
+++ b/themes/defaut/header.php
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="<?php $plxShow->charset('min'); ?>">
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0">
-	<title><?php $plxShow->pageTitle(); ?></title>
+	<title><?php $plxShow->mainTitle(); ?></title>
 <?php
 	$plxShow->meta('description');
 	$plxShow->meta('keywords');


### PR DESCRIPTION
Actuellement le titre présent dans le header html est le titre du bloc + la description, ce qui est trop long.
Les moteurs de recherche le signalent comme ne respectant pas les règles SEO.
Cette PR fait en sorte que la balise titre dans le header soit juste le titre du site.