### PR TITLE
Admin links

### DIFF
--- a/core/admin/auth.php
+++ b/core/admin/auth.php
@@ -48,7 +48,7 @@ if(isset($_SESSION['maxtry'])) {
 }
 
 # Incrémente le nombre de tentative
-$redirect = $plxAdmin->aConf['racine'] . 'core/admin/';
+$redirect = 'index.php';
 if(!empty($_GET['p']) AND $css=='') {
 
 	# on incremente la variable de session qui compte les tentatives de connexion

--- a/core/admin/auth.php
+++ b/core/admin/auth.php
@@ -10,7 +10,7 @@
 # Constante pour retrouver la page d'authentification
 const PLX_AUTHPAGE = true;
 
-include __DIR__ .'/prepend.php';
+include 'prepend.php';
 
 # Control du token du formulaire
 plxToken::validateFormToken($_POST);
@@ -57,7 +57,7 @@ if(!empty($_GET['p']) AND $css=='') {
 	$racine = parse_url($plxAdmin->aConf['racine']);
 	$get_p = parse_url(urldecode($_GET['p']));
 	$css = (!$get_p OR (isset($get_p['host']) AND $racine['host']!=$get_p['host']));
-	if(!$css AND !empty($get_p['path']) AND file_exists(PLX_ROOT.'core/admin/'.basename($get_p['path']))) {
+	if(!$css AND !empty($get_p['path']) AND file_exists(PLX_ADMIN_PATH . basename($get_p['path']))) {
 		# filtrage des parametres de l'url
 		$query='';
 		if(isset($get_p['query'])) {

--- a/core/admin/foot.php
+++ b/core/admin/foot.php
@@ -13,9 +13,9 @@
 <script src="../lib/drag-and-drop.js"></script>
 <script>
 	mediasManager.construct({
-		windowName : "<?php echo L_MEDIAS_TITLE ?>",
-		racine:	"<?php echo plxUtils::getRacine() ?>",
-		urlManager: "core/admin/medias.php"
+		windowName : '<?php echo L_MEDIAS_TITLE ?>',
+		racine:	'<?php echo plxUtils::getRacine() ?>',
+		urlManager: 'medias.php'
 	});
 
 	(function(query) {

--- a/core/admin/get_oauth_token.php
+++ b/core/admin/get_oauth_token.php
@@ -40,10 +40,10 @@ namespace PHPMailer\PHPMailer;
 use League\OAuth2\Client\Provider\Google;
 
 // Include PluXml requirements
-include __DIR__.'/prepend.php';
+include 'prepend.php';
 
 if (!isset($_GET['code']) && !isset($_GET['provider'])) {
-	include __DIR__ .'/top.php';
+	include 'top.php';
 ?>
 	<div class="inline-form action-bar">
 		<h2><?php echo L_CONFIG_ADVANCED ?></h2>
@@ -124,5 +124,6 @@ if (!isset($_GET['code'])) {
     if (!empty($tokenToStore)) {
     	$plxAdmin->editConfiguration($tokenToStore);
     }
-    header('Location: '.htmlentities($plxAdmin->aConf['racine'].'core/admin/parametres_avances.php'));
+    // header('Location: '.htmlentities($plxAdmin->aConf['racine'].'core/admin/parametres_avances.php'));
+    header('Location: parametres_avances.php'));
 }

--- a/core/admin/get_oauth_token.php
+++ b/core/admin/get_oauth_token.php
@@ -125,5 +125,5 @@ if (!isset($_GET['code'])) {
     	$plxAdmin->editConfiguration($tokenToStore);
     }
     // header('Location: '.htmlentities($plxAdmin->aConf['racine'].'core/admin/parametres_avances.php'));
-    header('Location: parametres_avances.php'));
+    header('Location: parametres_avances.php');
 }

--- a/core/admin/index.php
+++ b/core/admin/index.php
@@ -7,7 +7,7 @@
  * @author	Stephane F et Florent MONTHEL
  **/
 
-include __DIR__ .'/prepend.php';
+include 'prepend.php';
 
 # Control du token du formulaire
 plxToken::validateFormToken($_POST);

--- a/core/admin/parametres_plugins.php
+++ b/core/admin/parametres_plugins.php
@@ -39,7 +39,7 @@ function pluginsList($plugins, $defaultLang, $type) {
 			elseif(is_file(PLX_PLUGINS.$plugName.'/icon.gif'))
 				$icon=PLX_PLUGINS.$plugName.'/icon.gif';
 			else
-				$icon = PLX_ADMIN_PATH . 'theme/images/icon_plugin.png';
+				$icon = 'theme/images/icon_plugin.png';
 
 			# plugin activé uniquement côté site (<scope> == 'site')
 			if(empty($plugInstance) and $plugInstance=$plxAdmin->plxPlugins->getInstance($plugName)) {

--- a/core/admin/parametres_plugins.php
+++ b/core/admin/parametres_plugins.php
@@ -39,7 +39,7 @@ function pluginsList($plugins, $defaultLang, $type) {
 			elseif(is_file(PLX_PLUGINS.$plugName.'/icon.gif'))
 				$icon=PLX_PLUGINS.$plugName.'/icon.gif';
 			else
-			$icon=PLX_CORE.'admin/theme/images/icon_plugin.png';
+				$icon = PLX_ADMIN_PATH . 'theme/images/icon_plugin.png';
 
 			# plugin activé uniquement côté site (<scope> == 'site')
 			if(empty($plugInstance) and $plugInstance=$plxAdmin->plxPlugins->getInstance($plugName)) {

--- a/core/admin/parametres_themes.php
+++ b/core/admin/parametres_themes.php
@@ -61,7 +61,7 @@ class plxThemes {
 			$img=$this->racineTheme.$theme.'/preview.gif';
 
 		$current = $theme == $this->activeTheme ? ' current' : '';
-		$src = (!empty($img)) ? $img : PLX_ADMIN_PATH . 'theme/images/theme.png';
+		$src = (!empty($img)) ? $img : 'theme/images/theme.png';
 		return '<img class="img-preview' . $current . '" src="' . $src . '" alt="preview" />';
 	}
 

--- a/core/admin/parametres_themes.php
+++ b/core/admin/parametres_themes.php
@@ -61,10 +61,8 @@ class plxThemes {
 			$img=$this->racineTheme.$theme.'/preview.gif';
 
 		$current = $theme == $this->activeTheme ? ' current' : '';
-		if($img=='')
-			return '<img class="img-preview'.$current.'" src="'.PLX_CORE.'admin/theme/images/theme.png" alt="" />';
-		else
-			return '<img class="img-preview'.$current.'" src="'.$img.'" alt="" />';
+		$src = (!empty($img)) ? $img : PLX_ADMIN_PATH . 'theme/images/theme.png';
+		return '<img class="img-preview' . $current . '" src="' . $src . '" alt="preview" />';
 	}
 
 	public function getInfos($theme) {

--- a/core/admin/prepend.php
+++ b/core/admin/prepend.php
@@ -1,7 +1,6 @@
 <?php
 const PLX_ROOT = '../../';
-const PLX_CORE = PLX_ROOT .'core/';
-include PLX_CORE.'lib/config.php';
+include PLX_ROOT . 'core/lib/config.php';
 
 const SESSION_LIFETIME = 7200;
 

--- a/core/admin/top.php
+++ b/core/admin/top.php
@@ -48,7 +48,7 @@ if(isset($_GET["del"]) AND $_GET["del"]=="install") {
 <?php endif; ?>
 				</li>
 				<li>
-					<small><a class="logout" href="<?= PLX_CORE ?>admin/auth.php?d=1" title="<?= L_ADMIN_LOGOUT_TITLE ?>"><?= L_ADMIN_LOGOUT ?></a></small>
+					<small><a class="logout" href="auth.php?d=1" title="<?= L_ADMIN_LOGOUT_TITLE ?>"><?= L_ADMIN_LOGOUT ?></a></small>
 				</li>
 			</ul>
 			<ul class="unstyled-list profil">
@@ -70,40 +70,40 @@ if(isset($_GET["del"]) AND $_GET["del"]=="install") {
 					$menus = array();
 					$userId = ($_SESSION['profil'] < PROFIL_WRITER) ? '\d{3}' : $_SESSION['user'];
 					$nbartsmod = $plxAdmin->nbArticles('all', $userId, '_');
-					$arts_mod = $nbartsmod>0 ? '<span class="badge" onclick="window.location=\''.PLX_CORE.'admin/index.php?sel=mod&amp;page=1\';return false;">'.$nbartsmod.'</span>':'';
-					$menus[] = plxUtils::formatMenu(L_MENU_ARTICLES, PLX_CORE.'admin/index.php?page=1', L_MENU_ARTICLES_TITLE, false, false,$arts_mod);
+					$arts_mod = $nbartsmod>0 ? '<span class="badge" onclick="window.location=\''.'index.php?sel=mod&amp;page=1\';return false;">'.$nbartsmod.'</span>':'';
+					$menus[] = plxUtils::formatMenu(L_MENU_ARTICLES, 'index.php?page=1', L_MENU_ARTICLES_TITLE, false, false,$arts_mod);
 
 					if(isset($_GET['a'])) # edition article
-						$menus[] = plxUtils::formatMenu(L_NEW_ARTICLE, PLX_CORE.'admin/article.php', L_NEW_ARTICLE, false, false, '', false);
+						$menus[] = plxUtils::formatMenu(L_NEW_ARTICLE, 'article.php', L_NEW_ARTICLE, false, false, '', false);
 					else # nouvel article
-						$menus[] = plxUtils::formatMenu(L_NEW_ARTICLE, PLX_CORE.'admin/article.php', L_NEW_ARTICLE);
+						$menus[] = plxUtils::formatMenu(L_NEW_ARTICLE, 'article.php', L_NEW_ARTICLE);
 
-					$menus[] = plxUtils::formatMenu(L_MENU_MEDIAS, PLX_CORE.'admin/medias.php', L_MENU_MEDIAS_TITLE);
+					$menus[] = plxUtils::formatMenu(L_MENU_MEDIAS, 'medias.php', L_MENU_MEDIAS_TITLE);
 
 					if($_SESSION['profil'] <= PROFIL_MANAGER)
-						$menus[] = plxUtils::formatMenu(L_MENU_STATICS, PLX_CORE.'admin/statiques.php', L_MENU_STATICS_TITLE);
+						$menus[] = plxUtils::formatMenu(L_MENU_STATICS, 'statiques.php', L_MENU_STATICS_TITLE);
 
 					if(!empty($plxAdmin->aConf['allow_com']) and $_SESSION['profil'] <= PROFIL_MODERATOR) {
 						$nbcoms = $plxAdmin->nbComments('offline');
-						$coms_offline = $nbcoms>0 ? '<span class="badge" onclick="window.location=\''.PLX_CORE.'admin/comments.php?sel=offline&amp;page=1\';return false;">'.$plxAdmin->nbComments('offline').'</span>':'';
-						$menus[] = plxUtils::formatMenu(L_COMMENTS, PLX_CORE.'admin/comments.php?page=1', L_MENU_COMMENTS_TITLE, false, false, $coms_offline);
+						$coms_offline = $nbcoms>0 ? '<span class="badge" onclick="window.location=\''.'comments.php?sel=offline&amp;page=1\';return false;">'.$plxAdmin->nbComments('offline').'</span>':'';
+						$menus[] = plxUtils::formatMenu(L_COMMENTS, 'comments.php?page=1', L_MENU_COMMENTS_TITLE, false, false, $coms_offline);
 					}
 
 					if($_SESSION['profil'] <= PROFIL_EDITOR)
-						$menus[] = plxUtils::formatMenu(L_CATEGORIES, PLX_CORE.'admin/categories.php', L_MENU_CATEGORIES_TITLE);
+						$menus[] = plxUtils::formatMenu(L_CATEGORIES, 'categories.php', L_MENU_CATEGORIES_TITLE);
 
-					$menus[] = plxUtils::formatMenu(L_PROFIL, PLX_CORE.'admin/profil.php', L_MENU_PROFIL_TITLE);
+					$menus[] = plxUtils::formatMenu(L_PROFIL, 'profil.php', L_MENU_PROFIL_TITLE);
 
 					if($_SESSION['profil'] == PROFIL_ADMIN) {
-						$menus[] = plxUtils::formatMenu(L_MENU_CONFIG, PLX_CORE.'admin/parametres_base.php', L_MENU_CONFIG_TITLE, false, false, '', false);
+						$menus[] = plxUtils::formatMenu(L_MENU_CONFIG, 'parametres_base.php', L_MENU_CONFIG_TITLE, false, false, '', false);
 						if (preg_match('/parametres/',basename($_SERVER['SCRIPT_NAME']))) {
-							$menus[] = plxUtils::formatMenu(L_CONFIG_BASE, PLX_CORE.'admin/parametres_base.php', L_MENU_CONFIG_BASE_TITLE, 'menu-config');
-							$menus[] = plxUtils::formatMenu(L_MENU_CONFIG_VIEW, PLX_CORE.'admin/parametres_affichage.php', L_MENU_CONFIG_VIEW_TITLE, 'menu-config');
-							$menus[] = plxUtils::formatMenu(L_MENU_CONFIG_USERS, PLX_CORE.'admin/parametres_users.php', L_MENU_CONFIG_USERS_TITLE, 'menu-config');
-							$menus[] = plxUtils::formatMenu(L_CONFIG_ADVANCED, PLX_CORE.'admin/parametres_avances.php', L_MENU_CONFIG_ADVANCED_TITLE, 'menu-config');
-							$menus[] = plxUtils::formatMenu(L_THEMES, PLX_CORE.'admin/parametres_themes.php', L_THEMES_TITLE, 'menu-config');
-							$menus[] = plxUtils::formatMenu(L_MENU_CONFIG_PLUGINS, PLX_CORE.'admin/parametres_plugins.php', L_MENU_CONFIG_PLUGINS_TITLE, 'menu-config');
-							$menus[] = plxUtils::formatMenu(L_INFOS, PLX_CORE.'admin/parametres_infos.php', L_MENU_CONFIG_INFOS_TITLE, 'menu-config');
+							$menus[] = plxUtils::formatMenu(L_CONFIG_BASE, 'parametres_base.php', L_MENU_CONFIG_BASE_TITLE, 'menu-config');
+							$menus[] = plxUtils::formatMenu(L_MENU_CONFIG_VIEW, 'parametres_affichage.php', L_MENU_CONFIG_VIEW_TITLE, 'menu-config');
+							$menus[] = plxUtils::formatMenu(L_MENU_CONFIG_USERS, 'parametres_users.php', L_MENU_CONFIG_USERS_TITLE, 'menu-config');
+							$menus[] = plxUtils::formatMenu(L_CONFIG_ADVANCED, 'parametres_avances.php', L_MENU_CONFIG_ADVANCED_TITLE, 'menu-config');
+							$menus[] = plxUtils::formatMenu(L_THEMES, 'parametres_themes.php', L_THEMES_TITLE, 'menu-config');
+							$menus[] = plxUtils::formatMenu(L_MENU_CONFIG_PLUGINS, 'parametres_plugins.php', L_MENU_CONFIG_PLUGINS_TITLE, 'menu-config');
+							$menus[] = plxUtils::formatMenu(L_INFOS, 'parametres_infos.php', L_MENU_CONFIG_INFOS_TITLE, 'menu-config');
 						}
 					}
 
@@ -112,13 +112,13 @@ if(isset($_GET["del"]) AND $_GET["del"]=="install") {
 						if($plugInstance AND is_file(PLX_PLUGINS.$plugName.'/admin.php')) {
 							if($plxAdmin->checkProfil($plugInstance->getAdminProfil(),false)) {
 								if($plugInstance->adminMenu) {
-									$menu = plxUtils::formatMenu(plxUtils::strCheck($plugInstance->adminMenu['title']), PLX_CORE.'admin/plugin.php?p='.$plugName, plxUtils::strCheck($plugInstance->adminMenu['caption']));
+									$menu = plxUtils::formatMenu(plxUtils::strCheck($plugInstance->adminMenu['title']), 'plugin.php?p='.$plugName, plxUtils::strCheck($plugInstance->adminMenu['caption']));
 									if($plugInstance->adminMenu['position']!='')
 										array_splice($menus, ($plugInstance->adminMenu['position']-1), 0, $menu);
 									else
 										$menus[] = $menu;
 								} else {
-									$menus[] = plxUtils::formatMenu(plxUtils::strCheck($plugInstance->getInfo('title')), PLX_CORE.'admin/plugin.php?p='.$plugName, plxUtils::strCheck($plugInstance->getInfo('title')));
+									$menus[] = plxUtils::formatMenu(plxUtils::strCheck($plugInstance->getInfo('title')), 'plugin.php?p='.$plugName, plxUtils::strCheck($plugInstance->getInfo('title')));
 								}
 							}
 						}

--- a/core/lib/class.plx.feed.php
+++ b/core/lib/class.plx.feed.php
@@ -397,11 +397,11 @@ class plxFeed extends plxMotor {
 	public function getAdminComments() {
 		# Traitement initial
 		if($this->cible == '_') { # Commentaires hors ligne
-			$link = $this->racine.'core/admin/comments.php?sel=offline';
+			$link = $this->racine . substr(PLX_ADMIN_PATH, strlen(PLX_ROOT)) . 'comments.php?sel=offline';
 			$title = $this->aConf['title'].' - '.L_FEED_OFFLINE_COMMENTS;
 			$link_feed = $this->racine.'feed.php?admin' . $this->clef.'/commentaires/hors-ligne';
 		} else { # Commentaires en ligne
-			$link = $this->racine.'core/admin/comments.php?sel=online';
+			$link = $this->racine . substr(PLX_ADMIN_PATH, strlen(PLX_ROOT)) . 'comments.php?sel=online';
 			$title = $this->aConf['title'].' - '.L_FEED_ONLINE_COMMENTS;
 			$link_feed = $this->racine.'feed.php?admin'.$this->clef.'/commentaires/en-ligne';
 		}
@@ -422,12 +422,13 @@ class plxFeed extends plxMotor {
 <?php
 		# On va boucler sur les commentaires (s'il y en a)
 		if(!empty($this->plxRecord_coms)) {
+			$link_path = $this->racine . substr(PLX_ADMIN_PATH, strlen(PLX_ROOT)) . 'comment.php?c=';
 			while($this->plxRecord_coms->loop()) {
 				$artId = $this->plxRecord_coms->f('article') + 0;
 				$comId = $this->cible.$this->plxRecord_coms->f('article').'.'.$this->plxRecord_coms->f('numero');
 				$title_com = $this->plxRecord_coms->f('author').' @ ';
 				$title_com .= plxDate::formatDate($this->plxRecord_coms->f('date'), plxDate::FORMAT_TIME);
-				$link_com = $this->racine.'core/admin/comment.php?c='.$comId;
+				$link_com = $link_path . $comId;
 				# On vérifie la date de publication
 				if($this->plxRecord_coms->f('date') > $last_updated)
 					$last_updated = $this->plxRecord_coms->f('date');

--- a/core/lib/class.plx.feed.php
+++ b/core/lib/class.plx.feed.php
@@ -396,15 +396,13 @@ class plxFeed extends plxMotor {
 	 **/
 	public function getAdminComments() {
 		# Traitement initial
-		if($this->cible == '_') { # Commentaires hors ligne
-			$link = $this->racine . substr(PLX_ADMIN_PATH, strlen(PLX_ROOT)) . 'comments.php?sel=offline';
-			$title = $this->aConf['title'].' - '.L_FEED_OFFLINE_COMMENTS;
-			$link_feed = $this->racine.'feed.php?admin' . $this->clef.'/commentaires/hors-ligne';
-		} else { # Commentaires en ligne
-			$link = $this->racine . substr(PLX_ADMIN_PATH, strlen(PLX_ROOT)) . 'comments.php?sel=online';
-			$title = $this->aConf['title'].' - '.L_FEED_ONLINE_COMMENTS;
-			$link_feed = $this->racine.'feed.php?admin'.$this->clef.'/commentaires/en-ligne';
-		}
+		$url_base = $this->racine . substr(PLX_ADMIN_PATH, strlen(PLX_ROOT));
+
+		$offline = ($this->cible == '_'); # Commentaires en/hors ligne
+		$link = $url_base . 'comments.php?sel=' . ($offline ? 'offline' : 'online');
+		$title = $this->aConf['title'].' - ' . ($offline ? L_FEED_OFFLINE_COMMENTS : L_FEED_ONLINE_COMMENTS);
+		$link_feed = $this->racine.'feed.php?admin' . $this->clef . '/commentaires/' . ($offline ? 'hors-ligne' : 'en-ligne');
+
 		$lastBuildDate = (!empty($this->plxRecord_coms)) ? $this->plxRecord_coms->lastUpdated() : date(self::FORMAT_DATE);
 
 		# On affiche le flux
@@ -422,13 +420,12 @@ class plxFeed extends plxMotor {
 <?php
 		# On va boucler sur les commentaires (s'il y en a)
 		if(!empty($this->plxRecord_coms)) {
-			$link_path = $this->racine . substr(PLX_ADMIN_PATH, strlen(PLX_ROOT)) . 'comment.php?c=';
 			while($this->plxRecord_coms->loop()) {
 				$artId = $this->plxRecord_coms->f('article') + 0;
 				$comId = $this->cible.$this->plxRecord_coms->f('article').'.'.$this->plxRecord_coms->f('numero');
 				$title_com = $this->plxRecord_coms->f('author').' @ ';
 				$title_com .= plxDate::formatDate($this->plxRecord_coms->f('date'), plxDate::FORMAT_TIME);
-				$link_com = $link_path . $comId;
+				$link_com = $url_base . 'comment.php?c=' . $comId;
 				# On vérifie la date de publication
 				if($this->plxRecord_coms->f('date') > $last_updated)
 					$last_updated = $this->plxRecord_coms->f('date');

--- a/core/lib/class.plx.medias.php
+++ b/core/lib/class.plx.medias.php
@@ -105,7 +105,7 @@ class plxMedias {
 		$src = $this->path.$dir;
 		if(!is_dir($src)) return array();
 
-		$defaultSample = PLX_ADMIN_PATH . 'theme/images/file.png';
+		$defaultSample = 'theme/images/file.png';
 		$offset = strlen($this->path);
 		$files = array();
 		foreach(array_filter(

--- a/core/lib/class.plx.medias.php
+++ b/core/lib/class.plx.medias.php
@@ -105,7 +105,7 @@ class plxMedias {
 		$src = $this->path.$dir;
 		if(!is_dir($src)) return array();
 
-		$defaultSample = PLX_CORE.'admin/theme/images/file.png';
+		$defaultSample = PLX_ADMIN_PATH . 'theme/images/file.png';
 		$offset = strlen($this->path);
 		$files = array();
 		foreach(array_filter(

--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -925,7 +925,7 @@ class plxMotor {
 			}
 
 			# hiérarchisation et indentation des commentaires seulement sur les écrans requis
-			if (!preg_match('#comments\.php|comment\.php#',basename($_SERVER['SCRIPT_NAME']))) {
+			if (!preg_match('#comments?\.php#',basename($_SERVER['SCRIPT_NAME']))) {
 				$array = $this->parentChildSort_r('index', 'parent', $array);
 			}
 

--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -2140,4 +2140,8 @@ class plxShow {
 		}
 		return $this->urlRewrite('feed.php?' . $query);
 	}
+
+	public function admin() {
+		echo $this->plxMotor->urlRewrite(substr(PLX_ADMIN_PATH, str_len(PLX_CORE)));
+	}
 }

--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -2142,6 +2142,6 @@ class plxShow {
 	}
 
 	public function admin() {
-		echo $this->plxMotor->urlRewrite(substr(PLX_ADMIN_PATH, str_len(PLX_CORE)));
+		echo $this->plxMotor->urlRewrite(substr(PLX_ADMIN_PATH, strlen(PLX_ROOT)));
 	}
 }

--- a/core/lib/config.php
+++ b/core/lib/config.php
@@ -13,6 +13,9 @@ const PLX_URL_VERSION = PLX_URL_REPO.'/download/latest-version.txt';
 # Chargement de PLX_CONFIG_PATH
 include PLX_ROOT . 'config.php';
 
+const PLX_CORE = PLX_ROOT . 'core/';
+const PLX_ADMIN_PATH = PLX_CORE . 'admin/';
+
 # Gestion des erreurs PHP
 if(PLX_DEBUG){
 	error_reporting(E_ALL);

--- a/feed.php
+++ b/feed.php
@@ -1,7 +1,6 @@
 <?php
 const PLX_ROOT = './';
-const PLX_CORE = PLX_ROOT .'core/';
-include PLX_CORE.'lib/config.php';
+include PLX_ROOT . 'core/lib/config.php';
 
 # Autorise le cross-origin des flus rss/atom : Cross-Origin Resource Sharing
 # https://enable-cors.org/server_php.html

--- a/index.php
+++ b/index.php
@@ -1,8 +1,7 @@
 <?php
 
 const PLX_ROOT = './';
-const PLX_CORE = PLX_ROOT . 'core/';
-include PLX_CORE . 'lib/config.php'; # Autochargement des classes
+include PLX_ROOT . 'core/lib/config.php'; # Autochargement des classes
 
 # On démarre la session
 session_set_cookie_params(0, "/", $_SERVER['SERVER_NAME'], isset($_SERVER["HTTPS"]), true);

--- a/install.php
+++ b/install.php
@@ -6,8 +6,7 @@
 # --------------------------------------
 
 const PLX_ROOT = './';
-const PLX_CORE = PLX_ROOT . 'core/';
-include PLX_CORE . 'lib/config.php';
+include PLX_ROOT . 'core/lib/config.php';
 
 const PLX_INSTALLER = true;
 
@@ -219,14 +218,14 @@ plxUtils::cleanHeaders();
 	<meta charset="<?= strtolower(PLX_CHARSET) ?>" />
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0">
 	<title><?= L_PLUXML_INSTALLATION . ' ' . L_VERSION . ' ' . PLX_VERSION ?></title>
-	<link rel="stylesheet" type="text/css" href="<?= PLX_CORE ?>admin/theme/plucss.css" media="screen" />
-	<link rel="stylesheet" type="text/css" href="<?= PLX_CORE ?>admin/theme/theme.css" media="screen" />
+	<link rel="stylesheet" type="text/css" href="<?= PLX_ADMIN_PATH ?>theme/plucss.css" media="screen" />
+	<link rel="stylesheet" type="text/css" href="<?= PLX_ADMIN_PATH ?>theme/theme.css" media="screen" />
 	<script src="<?= PLX_CORE ?>lib/visual.js"></script>
 </head>
 <body>
 	<main class="main grid">
 		<aside class="aside col med-3 lrg-2 text-center">
-			<p><img src="<?= PLX_CORE ?>admin/theme/images/pluxml.png" alt="PluXml" /></p>
+			<p><img src="<?= PLX_ADMIN_PATH ?>theme/images/pluxml.png" alt="PluXml" /></p>
 			<p><a href="<?= PLX_URL_REPO ?>" target="_blank"><?= PLX_URL_REPO ?></a></p>
 		</aside>
 		<section

--- a/sitemap.php
+++ b/sitemap.php
@@ -1,7 +1,6 @@
 <?php
 const PLX_ROOT = './';
-const PLX_CORE = PLX_ROOT . 'core/';
-include PLX_CORE . 'lib/config.php';
+include PLX_ROOT . 'core/lib/config.php';
 
 # Creation de l'objet principal et lancement du traitement
 $plxMotor = plxMotor::getInstance();

--- a/themes/defaut/footer.php
+++ b/themes/defaut/footer.php
@@ -9,7 +9,7 @@
 				<?php $plxShow->lang('POWERED_BY') ?>&nbsp;<a href="<?= PLX_URL_REPO?>" title="<?php $plxShow->lang('PLUXML_DESCRIPTION') ?>">PluXml</a>
 				<?php $plxShow->lang('IN') ?>&nbsp;<?php $plxShow->chrono(); ?>&nbsp;
 				<?php $plxShow->httpEncoding() ?>&nbsp;-
-				<a rel="nofollow" href="<?php $plxShow->urlRewrite('core/admin/'); ?>" title="<?php $plxShow->lang('ADMINISTRATION') ?>"><?php $plxShow->lang('ADMINISTRATION') ?></a>
+				<a rel="nofollow" href="<?php $plxShow->admin(); ?>" title="<?php $plxShow->lang('ADMINISTRATION') ?>"><?php $plxShow->lang('ADMINISTRATION') ?></a>
 			</p>
 			<ul class="menu">
 				<?php  if($plxShow->plxMotor->aConf['enable_rss']) { ?>

--- a/update/index.php
+++ b/update/index.php
@@ -1,8 +1,7 @@
 <?php
 
 const PLX_ROOT = '../';
-const PLX_CORE = PLX_ROOT . 'core/';
-include PLX_CORE . 'lib/config.php';
+include PLX_ROOT . 'core/lib/config.php';
 
 const PLX_UPDATER = true;
 
@@ -43,14 +42,14 @@ plxToken::validateFormToken($_POST);
 	<meta charset="<?= strtolower(PLX_CHARSET) ?>" />
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0">
 	<title><?= L_UPDATE_TITLE.' '.plxUtils::strCheck($plxUpdater->newVersion) ?></title>
-	<link rel="stylesheet" type="text/css" href="<?= PLX_CORE ?>admin/theme/plucss.css" media="screen" />
-	<link rel="stylesheet" type="text/css" href="<?= PLX_CORE ?>admin/theme/theme.css" media="screen" />
-	<link rel="icon" href="<?= PLX_CORE ?>admin/theme/images/pluxml.gif" />
+	<link rel="stylesheet" type="text/css" href="<?= PLX_ADMIN_PATH ?>theme/plucss.css" media="screen" />
+	<link rel="stylesheet" type="text/css" href="<?= PLX_ADMIN_PATH ?>theme/theme.css" media="screen" />
+	<link rel="icon" href="<?= PLX_ADMIN_PATH ?>theme/images/pluxml.gif" />
 </head>
 <body>
 	<main class="main grid">
 		<aside class="aside col med-3 lrg-2 text-center">
-			<p><img src="<?= PLX_CORE ?>admin/theme/images/pluxml.png" alt="Logo" /></p>
+			<p><img src="<?= PLX_ADMIN_PATH ?>theme/images/pluxml.png" alt="Logo" /></p>
 			<p><a href="<?= PLX_URL_REPO ?>" target="_blank"><?= PLX_URL_REPO ?></a></p>
 		</aside>
 		<section class="section col med-9 med-offset-3 lrg-10 lrg-offset-2" style="margin-top: 0">


### PR DESCRIPTION
Simplification des liens, notamment dans le menu admin.
Creation de la constante PLX_ADMIN_PATH.

Il est ainsi possible de renommer le dossier core/admin. En ajustant cette constante, le site reste fonctionnel. 
Creation de la fonction plxShow::admin() pour afficher l'URL accessant au back-office. A utiliser dans le thème.

Evite aux hackers de savoir si un site est propulsé par PluXml en tentant d'accéder à la page index du dossier http://mon-site.com/core/admin/.