### PR TITLE
Fix $disabled dans parametres_avancees.php

### DIFF
--- a/core/admin/parametres_avances.php
+++ b/core/admin/parametres_avances.php
@@ -262,11 +262,9 @@ include __DIR__ .'/top.php';
 			</div>
 			<div class="col sml-12 med-7">
 				<?php plxUtils::printInput('smtpOauth2_refreshToken', $plxAdmin->aConf['smtpOauth2_refreshToken'], 'text', '', true); ?>
-				<?php
-					if (empty($plxAdmin->aConf['smtpOauth2_clientSecret']) AND empty($plxAdmin->aConf['smtpOauth2_clientId']) and empty($plxAdmin->aConf['smtpOauth2_emailAdress'])) {
-						$disabled = "disabled";
-					}
-				?>
+<?php
+	$disabled = (empty($plxAdmin->aConf['smtpOauth2_clientSecret']) AND empty($plxAdmin->aConf['smtpOauth2_clientId']) and empty($plxAdmin->aConf['smtpOauth2_emailAdress'])) ? 'disabled' : '';
+?>
 				<a href="get_oauth_token.php?provider=Google"><button type="button" <?php echo $disabled ?>><?php echo L_CONFIG_ADVANCED_SMTPOAUTH_GETTOKEN ?></button></a>
 			</div>
 		</div>


### PR DESCRIPTION
Tout est dans le titre

P.S. : Il faut mettre la police Fontello à jour par rapport à la branche master. Il manque des icônes dans la sidebar admin et dans auth.php.