### PR TITLE
Ajoute la navigation dans la page article côté site

### DIFF
--- a/core/lang/de/core.php
+++ b/core/lang/de/core.php
@@ -149,4 +149,10 @@ const L_FEED_ONLINE_COMMENTS	= 'Online Kommentare';
 const L_FEED_OFFLINE_COMMENTS	= 'Offline Kommentaire';
 const L_WRITTEN_BY				= 'Geschrieben von';
 
+# plxShow::artNavigation
+const L_ART_FIRST					= 'Erste';
+const L_ART_PREV					= 'Früher';
+const L_ART_NEXT					= 'Nächste';
+const L_ART_LAST					= 'Letzte';
+const L_ART_UP						= 'Oben';
 ?>

--- a/core/lang/en/core.php
+++ b/core/lang/en/core.php
@@ -149,4 +149,10 @@ const L_FEED_ONLINE_COMMENTS		= 'Online comments';
 const L_FEED_OFFLINE_COMMENTS		= 'Offline comments';
 const L_WRITTEN_BY					= 'Written by';
 
+# plxShow::artNavigation
+const L_ART_FIRST					= 'First';
+const L_ART_PREV					= 'Previous';
+const L_ART_NEXT					= 'Next';
+const L_ART_LAST					= 'Last';
+const L_ART_UP						= 'Up';
 ?>

--- a/core/lang/es/core.php
+++ b/core/lang/es/core.php
@@ -149,4 +149,10 @@ const L_FEED_ONLINE_COMMENTS		= 'Comentarios de usuarios';
 const L_FEED_OFFLINE_COMMENTS		= 'Comentarios sin conexión';
 const L_WRITTEN_BY					= 'Escrito por';
 
+# plxShow::artNavigation
+const L_ART_FIRST					= 'Primero';
+const L_ART_PREV					= 'Anterior';
+const L_ART_NEXT					= 'Siguiente';
+const L_ART_LAST					= 'Ultimo';
+const L_ART_UP						= 'Subir';
 ?>

--- a/core/lang/fr/core.php
+++ b/core/lang/fr/core.php
@@ -149,4 +149,10 @@ const L_FEED_ONLINE_COMMENTS		= 'Commentaires en ligne';
 const L_FEED_OFFLINE_COMMENTS		= 'Commentaires hors ligne';
 const L_WRITTEN_BY					= 'Rédigé par';
 
+# plxShow::artNavigation
+const L_ART_FIRST					= 'Premier';
+const L_ART_PREV					= 'Précèdent';
+const L_ART_NEXT					= 'Suivant';
+const L_ART_LAST					= 'Dernier';
+const L_ART_UP						= 'Remonter';
 ?>

--- a/core/lang/it/core.php
+++ b/core/lang/it/core.php
@@ -149,4 +149,10 @@ const L_FEED_ONLINE_COMMENTS		= 'Commenti online';
 const L_FEED_OFFLINE_COMMENTS		= 'Commenti chiusi';
 const L_WRITTEN_BY					= 'Pubblicato da';
 
+# plxShow::artNavigation
+const L_ART_FIRST					= 'Primo';
+const L_ART_PREV					= 'Precedente';
+const L_ART_NEXT					= 'Il prossimo';
+const L_ART_LAST					= 'Scorso';
+const L_ART_UP						= 'Vai su';
 ?>

--- a/core/lang/nl/core.php
+++ b/core/lang/nl/core.php
@@ -148,4 +148,10 @@ const L_FEED_ONLINE_COMMENTS		= 'Online commentaren';
 const L_FEED_OFFLINE_COMMENTS		= 'Offline commentaren';
 const L_WRITTEN_BY					= 'Geschreven door';
 
+# plxShow::artNavigation
+const L_ART_FIRST					= 'Eerste';
+const L_ART_PREV					= 'Vorige';
+const L_ART_NEXT					= 'De volgende';
+const L_ART_LAST					= 'Laatste';
+const L_ART_UP						= 'Omhoog gaan';
 ?>

--- a/core/lang/oc/core.php
+++ b/core/lang/oc/core.php
@@ -148,4 +148,11 @@ const L_FEED_NO_PRIVATE_URL			= 'Las URLs privadas son pas estadas inicializadas
 const L_FEED_ONLINE_COMMENTS		= 'Comentaris en linha';
 const L_FEED_OFFLINE_COMMENTS		= 'Comentaris fòra linha';
 const L_WRITTEN_BY					= 'Redigit per';
+
+# plxShow::artNavigation
+const L_ART_FIRST					= 'Premier';
+const L_ART_PREV					= 'Précèdent';
+const L_ART_NEXT					= 'Suivant';
+const L_ART_LAST					= 'Dernier';
+const L_ART_UP						= 'Remonter';
 ?>

--- a/core/lang/pl/core.php
+++ b/core/lang/pl/core.php
@@ -149,4 +149,10 @@ const L_FEED_ONLINE_COMMENTS		= 'Aktywne komentarze';
 const L_FEED_OFFLINE_COMMENTS		= 'Nieaktywne komentarze';
 const L_WRITTEN_BY					= 'Napisane przez';
 
+# plxShow::artNavigation
+const L_ART_FIRST					= 'Pierwszy';
+const L_ART_PREV					= 'Poprzedni';
+const L_ART_NEXT					= 'Kolejny';
+const L_ART_LAST					= 'Ostatni';
+const L_ART_UP						= 'Wzrastać';
 ?>

--- a/core/lang/pt/core.php
+++ b/core/lang/pt/core.php
@@ -149,4 +149,10 @@ const L_FEED_ONLINE_COMMENTS		= 'Comentários online';
 const L_FEED_OFFLINE_COMMENTS		= 'Comentários offline';
 const L_WRITTEN_BY					= 'Escrito por';
 
+# plxShow::artNavigation
+const L_ART_FIRST					= 'Primeiro';
+const L_ART_PREV					= 'Anterior';
+const L_ART_NEXT					= 'Próximo';
+const L_ART_LAST					= 'Último';
+const L_ART_UP						= 'Suba';
 ?>

--- a/core/lang/ro/core.php
+++ b/core/lang/ro/core.php
@@ -149,4 +149,10 @@ const L_FEED_ONLINE_COMMENTS		= 'Comentarii online';
 const L_FEED_OFFLINE_COMMENTS		= 'Comentarii offline';
 const L_WRITTEN_BY					= 'Scris de';
 
+# plxShow::artNavigation
+const L_ART_FIRST					= 'Primul';
+const L_ART_PREV					= 'Precedent';
+const L_ART_NEXT					= 'Următor';
+const L_ART_LAST					= 'Ultimul';
+const L_ART_UP						= 'Urca';
 ?>

--- a/core/lang/ru/core.php
+++ b/core/lang/ru/core.php
@@ -149,4 +149,10 @@ const L_FEED_ONLINE_COMMENTS		= 'Комментарии онлайн';
 const L_FEED_OFFLINE_COMMENTS		= 'Комментарии оффлайн';
 const L_WRITTEN_BY					= 'Автор';
 
+# plxShow::artNavigation
+const L_ART_FIRST					= 'первый';
+const L_ART_PREV					= 'предыдущий';
+const L_ART_NEXT					= 'следующий';
+const L_ART_LAST					= 'прошлой';
+const L_ART_UP						= 'подниматься';
 ?>

--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -11,27 +11,12 @@ const PLX_SHOW = true;
 
 class plxShow {
 
-	const ART_DIRECTIONS = array('first', 'prev', 'next', 'last', 'up');
-	const ART_DIRECTIONS_CAPTIONS = array(
-		'first'	=> L_ART_FIRST,
-		'prev'	=> L_ART_PREV,
-		'next'	=> L_ART_NEXT,
-		'last'	=> L_ART_LAST,
-		'up'	=> L_ART_UP,
-	);
-	const ART_DIRECTIONS_ICONS = array(
-		'first'	=> '◂◂',
-		'prev'	=> '◀',
-		'next'	=> '️️▶',
-		'last'	=> '▸▸',
-		'up'	=> '▲',
-	);
-	const ART_DIRECTIONS_EMOJIS = array(
-		'first'	=> '⏪', // :rewind:
-		'prev'	=> '◀️', // :arrow_backward:
-		'next'	=> '▶️', // :arrow_forward:
-		'last'	=> '⏩', // :fast_forward:
-		'up'	=> '⏫', // :arrow_double_up:
+	const ART_DIRECTIONS = array(
+		'first'	=> array('◂◂',	'⏪',	L_ART_FIRST),	// :rewind:
+		'prev'	=> array('◀',	'◀️',	L_ART_PREV),	// :arrow_backward:
+		'next'	=> array('️️▶',	'▶️',	L_ART_NEXT),	// :arrow_forward:
+		'last'	=> array('▸▸',	'⏩',	L_ART_LAST),	// :fast_forward:
+		'up'	=> array('▲',	'⏫',	L_ART_UP),		// :arrow_double_up:
 	);
 
 	public $plxMotor = false; # Objet plxMotor
@@ -1689,12 +1674,17 @@ class plxShow {
 	 * Méthode qui affiche les liens vers les premier, précèdent, suivant et dernier articles dans une catégorie, une archive ou pour un mot-clé (tag).
 	 *
 	 * @param	format gabarit pour afficher le résultat
+	 * @param	buttons liste des boutons à afficher
 	 * @author	Jean-Pierre Pourrez "bazooka07"
 	 * */
-	public function artNavigation($format='<li><a href="#url" rel="#dir" title="#title">#icon</a></li>') {
-		if(empty($_SESSION['previous']) or !array_key_exists('artIds', $_SESSION['previous'])) { return; }
+	public function artNavigation($format='<li><a href="#url" rel="#dir" title="#title">#icon</a></li>', $buttons='first prev next last up') {
+		if(
+			empty($_SESSION['previous']) or
+			!array_key_exists('artIds', $_SESSION['previous']) or
+			preg_match_all('@\b(?:' . implode('|', array_keys(self::ART_DIRECTIONS)). ')\b@', $buttons, $matches) == 0
+		) { return; }
 
-		foreach(self::ART_DIRECTIONS as $direction) {
+		foreach($matches[0] as $direction) {
 			if(!empty($_SESSION['previous']['artIds'][$direction]) or $direction == 'up') {
 				if($direction != 'up') {
 					# On pointe des articles
@@ -1736,18 +1726,24 @@ class plxShow {
 						}
 					}
 				}
+				list($icon, $emoji, $caption) = self::ART_DIRECTIONS[$direction];
 				echo strtr($format, array(
 					'#url'		=> $this->plxMotor->urlRewrite('index.php' . $query),
 					'#dir'		=> $direction,
 					'#title'	=> $title,
-					'#caption'	=> self::ART_DIRECTIONS_CAPTIONS[$direction],
-					'#icon'		=> self::ART_DIRECTIONS_ICONS[$direction],
-					'#emoji'	=> self::ART_DIRECTIONS_EMOJIS[$direction],
+					'#caption'	=> $caption,
+					'#icon'		=> $icon,
+					'#emoji'	=> $emoji,
 				)) . PHP_EOL;
 			}
 		}
 	}
 
+	/*
+	 * Imprime le lien canonique de la page
+	 *
+	 * @author Jean-Pierre Pourrez "Bazooka07"
+	 * */
 	public function artNavigationRange() {
 ?>
 <span><?= $_SESSION['previous']['position'] ?> / <?= $_SESSION['previous']['count'] ?></span>

--- a/themes/defaut/article.php
+++ b/themes/defaut/article.php
@@ -48,6 +48,15 @@
 
 					<?php $plxShow->artAuthorInfos('<div class="author-infos">#art_authorinfos</div>'); ?>
 
+			<div class="art-navigation-overlay">
+				<ul class="art-navigation">
+<?php
+		$plxShow->artNavigation();
+?>
+				</ul>
+				<?php $plxShow->artNavigationRange(); ?>
+			</div>
+
 					<?php include __DIR__.'/commentaires.php'; ?>
 
 				</div>

--- a/themes/defaut/css/theme.css
+++ b/themes/defaut/css/theme.css
@@ -507,6 +507,36 @@ article:after {
 	}
 }
 
+/* ----- article pagination ----- */
+.art-navigation-overlay {
+	display: flex;
+	margin: 0 0 0 0.25rem;
+}
+.art-navigation {
+	display: flex;
+	justify-content: center;
+	flex-grow: 1;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+.art-navigation a {
+	display: inline-block;
+	min-width: 3rem;
+	margin: 0 0.8rem;
+	padding-bottom: 0.3rem;
+	background-color: #258fd6;
+	color: #eee;
+	text-align: center;
+	font-size: 1.5rem;
+	text-transform: capitalize;
+	border-radius: 0.3rem;
+	cursor: pointer;
+}
+.art-navigation-overlay > span {
+	align-self: center;
+}
+
 @media (max-width: 767px) {
 	.header {
 		position: sticky;

--- a/themes/defaut/header.php
+++ b/themes/defaut/header.php
@@ -17,6 +17,8 @@
 	$plxShow->templateCss();
 	$plxShow->pluginsCss();
 ?>
+<?php $plxShow->artNavigation("\t" . '<link rel="#dir" href="#url" />'); ?>
+<?php $plxShow->canonical(); ?>
 	<link rel="alternate" type="application/rss+xml" title="<?php $plxShow->lang('ARTICLES_RSS_FEEDS') ?>" href="<?php $plxShow->urlPostsRssFeed() ?>" />
 	<link rel="alternate" type="application/rss+xml" title="<?php $plxShow->lang('COMMENTS_RSS_FEEDS') ?>" href="<?php $plxShow->urlRewrite('feed.php?rss/commentaires') ?>" />
 </head>


### PR DESCRIPTION
Permet de passer aux articles précèdent, suivant, premier et dernier
pour la catégorie, le mot-clé ou l'archive sélectionnée.

Ajoute les balises link de navigation dans <head>
Ainsi que l'adresse canonicale.