### PR TITLE
Le lien "prev" reste affiché si on est à l'article n°2 dans la série

### DIFF
--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -427,13 +427,12 @@ class plxMotor {
 				foreach($aFiles as $key=>$value) {
 					if(substr($value, 0, 4) == $this->cible) {
 						if($key > 0) {
-							$artIds['first'] = $aFiles[0];
-							if($key > 1) { $artIds['prev'] = $aFiles[$key - 1]; }
+							if($key > 1) { $artIds['first'] = $aFiles[0]; }
+							$artIds['prev'] = $aFiles[$key - 1];
 						}
 						if($key < count($aFiles) - 1) {
-							$artIds['last'] = $aFiles[count($aFiles) - 1];
-							if($key < count($aFiles) - 2) { $artIds['next'] = $aFiles[$key + 1]; }
-
+							if($key < count($aFiles) - 2) { $artIds['last'] = $aFiles[count($aFiles) - 1]; }
+							$artIds['next'] = $aFiles[$key + 1];
 						}
 						$_SESSION['previous']['position'] = $key + 1;
 						$_SESSION['previous']['count'] = count($aFiles);


### PR DESCRIPTION
Par contre, le lien "first" n'est plus affiché à cette position
Idem à l'autre nout de la série avec "next" et "last".

Voir discussion dans le forum avec assodefis le 26 mai :
https://forum.pluxml.org/discussion/6723/plxshow-navprevious-et-plxshow-navnext#latest