### PR TITLE
add aria-label for accessibility

### DIFF
--- a/themes/defaut/header.php
+++ b/themes/defaut/header.php
@@ -46,7 +46,7 @@
 
 						<div class="responsive-menu">
 							<label for="menu"></label>
-							<input type="checkbox" id="menu">
+							<input type="checkbox" id="menu" aria-label="menu">
 							<ul class="menu">
 								<?php $plxShow->staticList($plxShow->getLang('HOME'),'<li class="#static_class #static_status" id="#static_id"><a href="#static_url" title="#static_name">#static_name</a></li>'); ?>
 								<?php $plxShow->pageBlog('<li class="#page_class #page_status" id="#page_id"><a href="#page_url" title="#page_name">#page_name</a></li>'); ?>


### PR DESCRIPTION
In order to improve accessibility compliancy, an aria-label need to be added.
"Provide a valid label for form fields" warning from https://www.webaccessibility.com test.
When on-screen labels are present, they must be programmatically associated with form fields. When on-screen labels are not present, form fields must be given an accessible label.
When form fields do not have a programmatic (accessible) label, assistive technologies may incorrectly render the label or provide no label at all to users. When labels are not present or are incorrect, users of assistive technologies may not be able to complete a form.

The HTML5 specification has a new form field attribute called <code>placeholder</code>. This represents a label or hint, such as a word or short phrase, that is assigned to a form field such as an input field. The label or hint appears within the form field and goes away when users start typing. When the <code>placeholder</code> attribute is used, the label or hint may not be detected by assistive technologies. Therefore, developers should provide off-screen text in the <code>label</code> element of the form field or provide a <code>title</code attribute or use ARIA to provide an accessible name for the form field.