### PR TITLE
Diverses corrections pour l'authentification

### DIFF
--- a/core/admin/auth.php
+++ b/core/admin/auth.php
@@ -136,10 +136,10 @@ plxUtils::cleanHeaders();
     <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0">
     <title>PluXml - <?= L_AUTH_PAGE_TITLE ?></title>
     <meta http-equiv="Content-Type" content="text/html; charset=<?= strtolower(PLX_CHARSET); ?>" />
-    <link rel="stylesheet" type="text/css" href="<?= PLX_ADMIN_PATH ?>theme/css/knacss.css?v=<?= PLX_VERSION ?>" media="screen" />
-    <link rel="stylesheet" type="text/css" href="<?= PLX_ADMIN_PATH ?>theme/css/theme.css?v=<?= PLX_VERSION ?>" media="screen" />
-    <link rel="stylesheet" type="text/css" href="<?= PLX_ADMIN_PATH ?>theme/fontello/css/fontello.css?v=<?= PLX_VERSION ?>" media="screen" />
-    <link rel="icon" href="<?= PLX_ADMIN_PATH ?>theme/images/favicon.png" />
+    <link rel="stylesheet" type="text/css" href="theme/css/knacss.css?v=<?= PLX_VERSION ?>" media="screen" />
+    <link rel="stylesheet" type="text/css" href="theme/css/theme.css?v=<?= PLX_VERSION ?>" media="screen" />
+    <link rel="stylesheet" type="text/css" href="theme/fontello/css/fontello.css?v=<?= PLX_VERSION ?>" media="screen" />
+    <link rel="icon" href="theme/images/favicon.png" />
     <?php
     PlxUtils::printLinkCss($plxAdmin->aConf['custom_admincss_file'], true);
     PlxUtils::printLinkCss($plxAdmin->aConf['racine_plugins'].'admin.css', true);
@@ -154,7 +154,7 @@ plxUtils::cleanHeaders();
         <?php eval($plxAdmin->plxPlugins->callHook('AdminAuthBegin')) ?>
         <?php if (isset($_GET['action']) && $_GET['action'] == 'lostpassword'): ?>
             <div class="form mam pas">
-                <? eval($plxAdmin->plxPlugins->callHook('AdminAuthTopLostPassword')); ?>
+                <?php eval($plxAdmin->plxPlugins->callHook('AdminAuthTopLostPassword')); ?>
                 <form action="auth.php<?= !empty($redirect)?'?p='.plxUtils::strCheck(urlencode($redirect)):'' ?>" method="post" id="form_auth">
                     <fieldset class="man pan">
                         <div class="flex-container--column">
@@ -171,7 +171,7 @@ plxUtils::cleanHeaders();
         <?php elseif (isset($_GET['action']) && $_GET['action'] == 'changepassword'): ?>
             <div class="form mam pas">
                 <?php eval($plxAdmin->plxPlugins->callHook('AdminAuthTopChangePassword')); ?>
-                <?php if ($plxAdmin->verifyLostPasswordToken(isset($_GET['token']))):?>
+                <?php if ($plxAdmin->verifyLostPasswordToken(isset($_GET['token']))): ?>
                     <div>
                         <form action="auth.php<?= !empty($redirect)?'?p='.PlxUtils::strCheck(urlencode($redirect)):'' ?>" method="post" id="form_auth">
                             <fieldset class="man pan">
@@ -179,8 +179,8 @@ plxUtils::cleanHeaders();
                                     <?= PlxToken::getTokenPostMethod() ?>
                                     <input name="lostPasswordToken" value="<?= $_GET['token']; ?>" type="hidden" />
                                     <h1 class="h3-like txtcenter ma"><?= L_PROFIL_CHANGE_PASSWORD ?></h1>
-                                    <?php PlxUtils::printInput('password1', '', 'password', '10-255',false,'txt', L_PROFIL_PASSWORD, 'onkeyup="pwdStrength(this.id)"') ?>
-                                    <?php PlxUtils::printInput('password2', '', 'password', '10-255',false,'txt', L_PROFIL_CONFIRM_PASSWORD) ?>
+                                    <?php PlxUtils::printInput('password1', '', 'password', '10-255',false,'txt', L_PASSWORD, 'onkeyup="pwdStrength(this.id)"') ?>
+                                    <?php PlxUtils::printInput('password2', '', 'password', '10-255',false,'txt', L_CONFIRM_PASSWORD) ?>
                                     <?php eval($plxAdmin->plxPlugins->callHook('AdminAuthChangePassword'));	?>
                                     <input class="btn--primary" role="button" type="submit" name="editpassword" value="<?= L_PROFIL_UPDATE_PASSWORD ?>" />
                                     <a href="?p=/core/admin"><span class="w100 mts btn--info"><?= L_LOST_PASSWORD_LOGIN ?></span></a>

--- a/core/lang/de/install.php
+++ b/core/lang/de/install.php
@@ -21,7 +21,6 @@ const L_ERR_PASSWORD_CONFIRMATION		= 'Die Passwörter sind nicht identisch!';
 const L_PLUXML_INSTALLATION				= 'Installation von PluXml';
 const L_VERSION							= 'Version';
 const L_USERNAME						= 'Name des Administrators';
-const L_PASSWORD						= 'Passwort';
 const L_EMAIL						    = 'E-Mail-Adresse';
 const L_INPUT_INSTALL					= 'Installieren';
 const L_PWD_VERY_WEAK					= 'Sehr schwaches Passwort';

--- a/core/lang/en/admin.php
+++ b/core/lang/en/admin.php
@@ -127,7 +127,7 @@ const L_SUBMIT_BUTTON = 'Submit';
 const L_ERR_WRONG_PASSWORD = 'Incorrect login or password';
 const L_POWERED_BY = 'Powered by <a href="https://www.pluxml.org">PluXml</a>';
 const L_ERR_MAXLOGIN = 'Too many failed login<br />Retry in % s minutes';
-const L_LOST_PASSWORD = 'Lost your password ?';
+const L_LOST_PASSWORD = 'Lost your password&nbsp;?';
 const L_LOST_PASSWORD_LOGIN = 'Log in';
 const L_LOST_PASSWORD_SUCCESS = 'An email has been sent to the user';
 const L_LOST_PASSWORD_ERROR = 'The link has expired';

--- a/core/lang/en/install.php
+++ b/core/lang/en/install.php
@@ -21,7 +21,6 @@ const L_ERR_PASSWORD_CONFIRMATION		= 'Invalid password confirmation !';
 const L_PLUXML_INSTALLATION				= 'PluXml installation';
 const L_VERSION							= 'version';
 const L_USERNAME						= 'Admin username';
-const L_PASSWORD						= 'Password';
 const L_EMAIL						    = 'E-mail adress';
 const L_INPUT_INSTALL					= 'Install';
 const L_PWD_VERY_WEAK					= 'Very weak password';

--- a/core/lang/es/admin.php
+++ b/core/lang/es/admin.php
@@ -132,7 +132,7 @@ const L_SUBMIT_BUTTON = 'Enviar';
 const L_ERR_WRONG_PASSWORD = 'Nombre de usuario o contraseña incorrectos';
 const L_POWERED_BY = 'Generado con <a href="https://www.pluxml.org">PluXml</a>';
 const L_ERR_MAXLOGIN = 'Demasiado error en el inicio de sesión<br />Reintentar en% s minutos';
-const L_LOST_PASSWORD = 'Contraseña olvidada ?';
+const L_LOST_PASSWORD = 'Contraseña olvidada&nbsp;?';
 const L_LOST_PASSWORD_LOGIN = 'Iniciar sesión';
 const L_LOST_PASSWORD_SUCCESS = 'Se ha enviado un correo electrónico al usuario';
 const L_LOST_PASSWORD_ERROR = 'El enlace ha caducado';

--- a/core/lang/es/install.php
+++ b/core/lang/es/install.php
@@ -21,7 +21,6 @@ const L_ERR_PASSWORD_CONFIRMATION	= 'La contraseña es incorrecta!';
 const L_PLUXML_INSTALLATION			= 'Instalación de PluXml';
 const L_VERSION						= 'versión';
 const L_USERNAME					= 'Nombre del administrador';
-const L_PASSWORD					= 'Contraseña';
 const L_EMAIL						= 'Dirección de correo electrónico';
 const L_INPUT_INSTALL				= 'Instalar';
 const L_PWD_VERY_WEAK				= 'Contraseña muy débil';

--- a/core/lang/fr/admin.php
+++ b/core/lang/fr/admin.php
@@ -126,7 +126,7 @@ const L_SUBMIT_BUTTON = 'Valider';
 const L_ERR_WRONG_PASSWORD = 'Login et/ou mot de passe incorrect';
 const L_POWERED_BY = 'Généré par <a href="https://www.pluxml.org">PluXml</a>';
 const L_ERR_MAXLOGIN = 'Nombre de tentative atteint<br />Réessayez dans %s minutes';
-const L_LOST_PASSWORD = 'Mot de passe oublié ?';
+const L_LOST_PASSWORD = 'Mot de passe oublié&nbsp;?';
 const L_LOST_PASSWORD_LOGIN = 'Se connecter';
 const L_LOST_PASSWORD_SUCCESS = 'Un e-mail a été envoyé à l\'utilisateur';
 const L_LOST_PASSWORD_ERROR = 'Le lien est expiré';
@@ -451,8 +451,8 @@ const L_PROFIL = 'Profil';
 const L_PROFIL_USER = 'Nom d\'utilisateur';
 const L_INFOS = 'Informations';
 const L_PROFIL_UPDATE = 'Modifier votre profil';
-const L_PROFIL_CHANGE_PASSWORD = 'Changement du mot de passe';
-const L_PROFIL_UPDATE_PASSWORD = 'Changer votre mot de passe';
+const L_PROFIL_CHANGE_PASSWORD = 'Changement du&nbsp;mot&nbsp;de&nbsp;passe';
+const L_PROFIL_UPDATE_PASSWORD = 'Changer votre&nbsp;mot&nbsp;de&nbsp;passe';
 
 // statique.php
 

--- a/core/lang/fr/install.php
+++ b/core/lang/fr/install.php
@@ -21,7 +21,6 @@ const L_ERR_PASSWORD_CONFIRMATION		= 'Confirmation du mot de passe incorrecte.';
 const L_PLUXML_INSTALLATION				= 'Installation de PluXml';
 const L_VERSION							= 'version';
 const L_USERNAME						= 'Nom de l\'administrateur';
-const L_PASSWORD						= 'Mot de passe';
 const L_EMAIL						    = 'Adresse email';
 const L_INPUT_INSTALL					= 'Installer';
 const L_PWD_VERY_WEAK					= 'Mot de passe très faible';

--- a/core/lang/it/admin.php
+++ b/core/lang/it/admin.php
@@ -119,7 +119,7 @@ const L_SUBMIT_BUTTON = 'Collegati';
 const L_ERR_WRONG_PASSWORD = 'Nome utente e/o password non corretti';
 const L_POWERED_BY = 'Powered by <a href="https://www.pluxml.org">PluXml</a>';
 const L_ERR_MAXLOGIN = 'Troppi fallito login<br />Riprova tra% s minuti';
-const L_LOST_PASSWORD = 'Password dimenticata ?';
+const L_LOST_PASSWORD = 'Password dimenticata&nbsp;?';
 const L_LOST_PASSWORD_LOGIN = 'Accesso';
 const L_LOST_PASSWORD_SUCCESS = 'E\' stata inviata una e-mail all\'utente';
 const L_LOST_PASSWORD_ERROR = 'Il collegamento è scaduto';

--- a/core/lang/it/install.php
+++ b/core/lang/it/install.php
@@ -21,7 +21,6 @@ const L_ERR_PASSWORD_CONFIRMATION		= 'Conferma della password non corretta !';
 const L_PLUXML_INSTALLATION				= 'Installazione di PluXml';
 const L_VERSION							= 'versione';
 const L_USERNAME						= 'Nome dell\'amministratore';
-const L_PASSWORD						= 'Password';
 const L_EMAIL						    = 'Indirizzo email';
 const L_INPUT_INSTALL					= 'Installa';
 const L_PWD_VERY_WEAK					= 'Password molto debole';

--- a/core/lang/nl/install.php
+++ b/core/lang/nl/install.php
@@ -21,7 +21,6 @@ const L_ERR_PASSWORD_CONFIRMATION		= 'Bevestiging van wachtwoord mislukt !';
 const L_PLUXML_INSTALLATION				= 'Installatie van PluXml';
 const L_VERSION							= 'versie';
 const L_USERNAME						= 'Naam van de beheerder';
-const L_PASSWORD						= 'Wachtwoord';
 const L_EMAIL						    = 'E-mailadres';
 const L_INPUT_INSTALL					= 'Installeer';
 const L_PWD_VERY_WEAK					= 'Zeer zwak wachtwoord';

--- a/core/lang/oc/admin.php
+++ b/core/lang/oc/admin.php
@@ -133,7 +133,7 @@ const L_SUBMIT_BUTTON = 'Validar';
 const L_ERR_WRONG_PASSWORD = 'Identificant e/o senhal incorrèct';
 const L_POWERED_BY = 'Generat per <a href="https://www.pluxml.org">PluXml</a>';
 const L_ERR_MAXLOGIN = 'Nombre de pròvas atent<br />Tornatz ensajar d’aquí %s minutas';
-const L_LOST_PASSWORD = 'Senhal oblidat ?';
+const L_LOST_PASSWORD = 'Senhal oblidat&nbsp;?';
 const L_LOST_PASSWORD_LOGIN = 'Se connectar';
 const L_LOST_PASSWORD_SUCCESS = 'Corrièl enviat a l’utilizaire';
 const L_LOST_PASSWORD_ERROR = 'Lo ligam a expirat';

--- a/core/lang/oc/install.php
+++ b/core/lang/oc/install.php
@@ -21,7 +21,6 @@ const L_ERR_PASSWORD_CONFIRMATION		= 'Confirmacion del senhal incorrècta !';
 const L_PLUXML_INSTALLATION				= 'Installacion de PluXml';
 const L_VERSION							= 'version';
 const L_USERNAME						= 'Nom de l\'administrator';
-const L_PASSWORD						= 'Senhal';
 const L_EMAIL						    = 'Adreça electronica';
 const L_INPUT_INSTALL					= 'Installar';
 const L_PWD_VERY_WEAK					= 'Senhal fòrça feble';

--- a/core/lang/pl/install.php
+++ b/core/lang/pl/install.php
@@ -21,7 +21,6 @@ const L_ERR_PASSWORD_CONFIRMATION		= 'Niepoprawne potwierdzenie hasła';
 const L_PLUXML_INSTALLATION				= 'Instalacja PluXml';
 const L_VERSION							= 'wersja';
 const L_USERNAME						= 'Nazwa admina';
-const L_PASSWORD						= 'Hasło';
 const L_EMAIL						    = 'Adres e-mail';
 const L_INPUT_INSTALL					= 'Zainstaluj';
 const L_PWD_VERY_WEAK					= 'Bardzo słabe hasło';

--- a/core/lang/pt/install.php
+++ b/core/lang/pt/install.php
@@ -21,7 +21,6 @@ const L_ERR_PASSWORD_CONFIRMATION		= 'Confirmação da senha incorrecta !';
 const L_PLUXML_INSTALLATION				= 'Instalação de PluXml';
 const L_VERSION							= 'versão';
 const L_USERNAME						= 'Nome do administrador';
-const L_PASSWORD						= 'Senha';
 const L_EMAIL						    = 'Endereço de e-mail';
 const L_INPUT_INSTALL					= 'Instalar';
 const L_PWD_VERY_WEAK					= 'Senha muito fraca';

--- a/core/lang/ro/install.php
+++ b/core/lang/ro/install.php
@@ -21,7 +21,6 @@ const L_ERR_PASSWORD_CONFIRMATION		= 'Confirmarea parolă incorectă !';
 const L_PLUXML_INSTALLATION				= 'Instalaţia PluXml';
 const L_VERSION							= 'versiunea';
 const L_USERNAME						= 'Numele Administratorului';
-const L_PASSWORD						= 'Parola';
 const L_EMAIL						    = 'Adresa de email';
 const L_INPUT_INSTALL					= 'Instalează';
 const L_PWD_VERY_WEAK					= 'Parola foarte slabă';

--- a/core/lang/ru/install.php
+++ b/core/lang/ru/install.php
@@ -21,7 +21,6 @@ const L_ERR_PASSWORD_CONFIRMATION		= 'Неверный пароль!';
 const L_PLUXML_INSTALLATION				= 'Установка PluXml, ';
 const L_VERSION							= 'версия';
 const L_USERNAME						= 'Имя Администратора';
-const L_PASSWORD						= 'Пароль';
 const L_EMAIL						    = 'Адрес электронной почты';
 const L_INPUT_INSTALL					= 'Установка';
 const L_PWD_VERY_WEAK					= 'очень слабый пароль';

--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -389,8 +389,8 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 
 					$placeholdersValues = array(
 						"##LOGIN##"			=> $user['login'],
-						"##URL_PASSWORD##"	=> $this->aConf['racine'].'core/admin/auth.php?action=changepassword&token='.$lostPasswordToken,
-						"##URL_EXPIRY##"	=> $tokenExpiry
+						"##URL_PASSWORD##"	=> $this->aConf['racine'] . substr(PLX_ADMIN_PATH, strlen(PLX_ROOT)) . 'auth.php?action=changepassword&token='. $lostPasswordToken,
+						"##URL_EXPIRY##"	=> $tokenExpiry,
 					);
 					if (($mail ['body'] = $this->aTemplates[$templateName]->getTemplateGeneratedContent($placeholdersValues)) != '1') {
 						$mail['subject'] = $this->aTemplates[$templateName]->getTemplateEmailSubject();
@@ -434,14 +434,13 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 	 */
 	public function verifyLostPasswordToken($token) {
 
-		$valid = false;
-
 		foreach($this->aUsers as $user_id => $user) {
-			if ($user['password_token'] == $token  AND $user['password_token_expiry'] >= date('YmdHi')) {
-				$valid = true;
+			if ($user['password_token'] == $token) {
+				return ($user['password_token_expiry'] >= date('YmdHi'));
+				break;
 			}
 		}
-		return $valid;
+		return false;
 	}
 
 	/**

--- a/core/lib/config.php
+++ b/core/lib/config.php
@@ -58,7 +58,7 @@ const XML_HEADER = '<?xml version="1.0" encoding="' . PLX_CHARSET . '" ?>' . PHP
 # Langue par défaut
 const DEFAULT_LANG = 'en';
 
-# profils utilisateurs de pluxml. Look at core/admin/top.php for more information
+# profils utilisateurs de pluxml. Look at ../top.php for more information
 const PROFIL_ADMIN		= 0; // all grants
 const PROFIL_MANAGER	= 1; // grants for statiques, comments, categories, articles,
 const PROFIL_MODERATOR	= 2; // grants for comments, categories


### PR DESCRIPTION
Dans plxAdmin::sendLostPasswordEmail(),
  remplacer 'core/admin/' par constantes
Refacto plxAmdin::verifyLostPasswordToken()
Emploi traductions existantes : remplacer L_PROFIL_PASSWORD par
L_PASSWORD. Idem L_PROFIL_CONFIRM_PASSWORD.
Suppression doublon clé de traduction L_PASSWORD dans core/lang/??/install.php
Utilisation espaces insécables pour page authetification.