### PR TITLE
$instance de plxAdmin est hérité de plxMotor !

### DIFF
--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -20,7 +20,6 @@ class plxAdmin extends plxMotor {
 	const EMPTY_FIELDS_USER = array('infos', 'password_token', 'password_token_expiry');
 	const EMPTY_FIELD_STATIQUES = array('title_htmltag', 'meta_description', 'meta_keywords');
 
-	private static $instance = null;
 	public $update_link = PLX_URL_REPO; // overwritten by self::checmMaj()
 
 	/**
@@ -30,9 +29,9 @@ class plxAdmin extends plxMotor {
 	 * @author	Stephane F
 	 **/
 	public static function getInstance(){
-		if (!isset(self::$instance))
-			self::$instance = new plxAdmin(path('XMLFILE_PARAMETERS'));
-		return self::$instance;
+		if (empty(parent::$instance))
+			parent::$instance = new plxAdmin(path('XMLFILE_PARAMETERS'));
+		return parent::$instance;
 	}
 
 	/**
@@ -499,8 +498,8 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 					$this->aUsers[$user_id] = array(
 						'login'					=> trim($content[$user_id . '_login']),
 						'name'					=> trim($content[$user_id . '_name']),
-						'active'				=> ($_SESSION['user']==$user_id ? $this->aUsers[$user_id]['active'] : $content[$user_id . '_active']),
-						'profil'				=> ($_SESSION['user']==$user_id ? $this->aUsers[$user_id]['profil'] : $content[$user_id . '_profil']),
+						'active'				=> (!empty($_SESSION['user']) and $_SESSION['user']==$user_id ? $this->aUsers[$user_id]['active'] : $content[$user_id . '_active']),
+						'profil'				=> (!empty($_SESSION['user']) AND $_SESSION['user'] == $user_id ? $this->aUsers[$user_id]['profil'] : $content[$user_id . '_profil']),
 						'password'				=> $password,
 						'salt'					=> $salt,
 						'email'					=> $email,
@@ -1184,7 +1183,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 				'active'	=> intval(!in_array('draft', $content['catId']))
 			);
 			$this->editTags();
-			$msg = ($content['artId'] == '0000' OR empty($content['artId'])) ? L_ARTICLE_SAVE_SUCCESSFUL : L_ARTICLE_MODIFY_SUCCESSFUL;
+			$msg = (empty($content['artId']) OR $content['artId'] == '0000') ? L_ARTICLE_SAVE_SUCCESSFUL : L_ARTICLE_MODIFY_SUCCESSFUL;
 
 			if(!empty($this->plxPlugins)) {
 				# Hook plugins

--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -26,7 +26,7 @@ class plxAdmin extends plxMotor {
 	 * Méthode qui se charger de créer le Singleton plxAdmin
 	 *
 	 * @return	self	return une instance de la classe plxAdmin
-	 * @author	Stephane F
+	 * @author	Stephane F, Jean-Pierre Pourerz "Bazooka07"
 	 **/
 	public static function getInstance(){
 		if (empty(parent::$instance))

--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -498,8 +498,8 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 					$this->aUsers[$user_id] = array(
 						'login'					=> trim($content[$user_id . '_login']),
 						'name'					=> trim($content[$user_id . '_name']),
-						'active'				=> (!empty($_SESSION['user']) and $_SESSION['user']==$user_id ? $this->aUsers[$user_id]['active'] : $content[$user_id . '_active']),
-						'profil'				=> (!empty($_SESSION['user']) AND $_SESSION['user'] == $user_id ? $this->aUsers[$user_id]['profil'] : $content[$user_id . '_profil']),
+						'active'				=> (!empty($_SESSION['user']) and $_SESSION['user']==$user_id) ? $this->aUsers[$user_id]['active'] : $content[$user_id . '_active'],
+						'profil'				=> (!empty($_SESSION['user']) AND $_SESSION['user'] == $user_id) ? $this->aUsers[$user_id]['profil'] : $content[$user_id . '_profil'],
 						'password'				=> $password,
 						'salt'					=> $salt,
 						'email'					=> $email,

--- a/core/lib/class.plx.feed.php
+++ b/core/lib/class.plx.feed.php
@@ -12,18 +12,16 @@ const PLX_FEED = true;
 class plxFeed extends plxMotor {
 	const FORMAT_DATE = 'YmdHi';
 
-	private static $instance = null;
-
 	/**
 	 * Méthode qui se charger de créer le Singleton plxFeed
 	 *
 	 * @return	plxFeed		retourne une instance de la classe plxFeed
-	 * @author	Stephane F
+	 * @author	Stephane F, J.P. Pourrez "Bazooka07"
 	 **/
 	public static function getInstance(){
-		if (!isset(self::$instance))
-			self::$instance = new plxFeed(path('XMLFILE_PARAMETERS'));
-		return self::$instance;
+		if (empty(parent::$instance))
+			parent::$instance = new plxFeed(path('XMLFILE_PARAMETERS'));
+		return parent::$instance;
 	}
 
 	/**

--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -104,7 +104,7 @@ class plxMotor {
 	public $plxErreur = null; # Objet plxErreur
 	public $plxPlugins = null; # Objet plxPlugins
 
-	private static $instance;
+	protected static $instance = null; // protected is required by plxAdmin
 
 	/**
 	 * Méthode qui se charger de créer le Singleton plxMotor
@@ -113,8 +113,7 @@ class plxMotor {
 	 * @author	Stephane F
 	 **/
 	public static function getInstance(){
-		if (!isset(self::$instance)) {
-			self::$instance = false;
+		if (empty(self::$instance)) {
 			self::$instance = new plxMotor(path('XMLFILE_PARAMETERS'));
 		}
 		return self::$instance;


### PR DESCRIPTION
Fix plxAdmin::getInstance() (parent::$instance)
Fix test $_SESSION['user'] dans plxAdmin::editUsers()

Actuellement dans le back-office, tous les appels à plxMotor::getIsntance() créent une nouvelle instance plxMotor mais n'utilisent pas l'instance plxAdmin existante. D'où tentative de créer à nouveau la constante PLX_SITE_LANG dans plxAdmin::__construct()