### PR TITLE
Fixes for plxShow artNavigation[Range]() & 3 new hooks

### DIFF
--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -1708,9 +1708,13 @@ class plxShow {
 	 *
 	 * @param string $format the template to display
 	 * @param string $buttons buttons list to display
-	 * @author Jean-Pierre Pourrez "bazooka07"
+	 * @author Jean-Pierre Pourrez "bazooka07", sudwevdesign
 	 */
 	public function artNavigation($format='<li><a href="#url" rel="#dir" title="#title">#icon</a></li>', $buttons='first prev next last up') {
+
+		# Hook Plugins
+		if(eval($this->plxMotor->plxPlugins->callHook('plxShowArtNavigationBegin'))) return;
+
 		if(
 			empty($_SESSION['previous']) or
 			!array_key_exists('artIds', $_SESSION['previous']) or
@@ -1744,22 +1748,31 @@ class plxShow {
 						case 'archives':
 							$query .= '/' . substr($cible, 0, 4);
 							if(strlen($cible) > 4) { $query .= '/' . substr($cible, 4); }
-							$title = ucfirst('L_ARCHIVES') . ' ' . $cible;
-							$bypage = $this->aConf['bypage_archives'];
+							$title = ucfirst(L_ARCHIVES) . ' ' . $cible;
+							$bypage = $this->plxMotor->aConf['bypage_archives'];
 							break;
 						default: # home
 							$query = '';
+							$bypage = $this->plxMotor->bypage;#maybe here fix this***
 					}
 
 					if(strpos($format, '<link') === false) {
-						if($bypage <= 0) { $bypage = $this->plxMotor->bypage; }
+						if($bypage <= 0) { $bypage = $this->plxMotor->bypage; }# *** Notice: Undefined variable: bypage : index.php?article1/premier-article
 						$page = intval(ceil($_SESSION['previous']['position'] / $bypage));
 						if($page > 1) {
 							$query .= (($mode != 'home') ? '/page' : '?page') . $page;
 						}
 					}
+
+					# Hook Plugins
+					if(eval($this->plxMotor->plxPlugins->callHook('plxShowArtNavigation'))) return;
+
 				}
 				list($icon, $emoji, $caption) = self::ART_DIRECTIONS[$direction];
+
+				# Hook Plugins
+				if(eval($this->plxMotor->plxPlugins->callHook('plxShowArtNavigationEnd'))) return;
+
 				echo strtr($format, array(
 					'#url'		=> $this->plxMotor->urlRewrite('index.php' . $query),
 					'#dir'		=> $direction,
@@ -1778,6 +1791,7 @@ class plxShow {
 	 * @author Jean-Pierre Pourrez "Bazooka07"
 	 */
 	public function artNavigationRange() {
+		if(empty($_SESSION['previous'])) return;
 ?>
 <span><?= $_SESSION['previous']['position'] ?> / <?= $_SESSION['previous']['count'] ?></span>
 <?php


### PR DESCRIPTION
* Fix missing plxMotor
* Fix Notice: Undefined variable: bypage (line 1760) : other modes than categorie, tags & archives : like ?article1/myfirstart
* Fix $title = ucfirst('L_ARCHIVES')

* (maybe bad) Fix Notice: Undefined index: previous : preview mode or direct access like : index.php?article1
```
artNavigationRange() {
		if(empty($_SESSION['previous'])) return;
```