### PR TITLE
Fix typo core/lang/en/admin.php

### DIFF
--- a/core/lang/en/admin.php
+++ b/core/lang/en/admin.php
@@ -529,5 +529,5 @@ const L_THEMES_TITLE = 'Manage themes';
 const L_HELP = 'Help';
 const L_HELP_TITLE = 'See help';
 const L_BACK_TO_THEMES = 'Back to themes';
-const L_CONFIG_THEME_UPDATE = 'Select this theme'
+const L_CONFIG_THEME_UPDATE = 'Select this theme';
 ?>


### PR DESCRIPTION
manque ";" dans core/lan/en/admin.php