### PR TITLE
Urlify 5.8.4 201113

### DIFF
--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -631,7 +631,7 @@ class plxMotor {
 	 *
 	 * @param	publi	before, after ou all => on récupère tous les fichiers (date) ?
 	 * @return	boolean	vrai si articles trouvés, sinon faux
-	 * @author	Stéphane F
+	 * @author	Stéphane F, J.P. Pourrez (bazooka07)
 	 **/
 	public function getArticles($publi='before') {
 
@@ -685,7 +685,7 @@ class plxMotor {
 	 *
 	 * @param	filename	fichier de l'article à parser
 	 * @return	array
-	 * @author	Anthony GUÉRIN, Florent MONTHEL, Stéphane F
+	 * @author	Anthony GUÉRIN, Florent MONTHEL, Stéphane F, J.P. Pourrez (bazooka07)
 	 **/
 	public function parseArticle($filename) {
 

--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -639,14 +639,21 @@ class plxMotor {
 		$start = $this->bypage*($this->page-1);
 		# On recupere nos fichiers (tries) selon le motif, la pagination, la date de publication
 		if($aFiles = $this->plxGlob_arts->query($this->motif,'art',$this->tri,$start,$this->bypage,$publi)) {
-			# on mémorise le nombre total d'articles trouvés
-			foreach($aFiles as $k=>$v) # On parcourt tous les fichiers
-				$array[$k] = $this->parseArticle(PLX_ROOT.$this->aConf['racine_articles'].$v);
+			# On analyse tous les fichiers
+			$artsList = array();
+			foreach($aFiles as $v) {
+				$art = $this->parseArticle(PLX_ROOT . $this->aConf['racine_articles'] . $v);
+				if(!empty($art)) {
+					$artsList[] = $art;
+				}
+			}
 			# On stocke les enregistrements dans un objet plxRecord
-			$this->plxRecord_arts = new plxRecord($array);
+			$this->plxRecord_arts = new plxRecord($artsList);
 			return true;
 		}
-		else return false;
+
+		$this->plxRecord_arts = false;
+		return false;
 	}
 
 	/**
@@ -669,6 +676,8 @@ class plxMotor {
 				'artUrl'	=> $capture[5]
 			);
 		}
+
+		return false;
 	}
 
 	/**
@@ -680,43 +689,53 @@ class plxMotor {
 	 **/
 	public function parseArticle($filename) {
 
-		# Mise en place du parseur XML
-		$data = implode('',file($filename));
-		$parser = xml_parser_create(PLX_CHARSET);
-		xml_parser_set_option($parser,XML_OPTION_CASE_FOLDING,0);
-		xml_parser_set_option($parser,XML_OPTION_SKIP_WHITE,0);
-		xml_parse_into_struct($parser,$data,$values,$iTags);
-		xml_parser_free($parser);
-		# Recuperation des valeurs de nos champs XML
-		$art['title'] = plxUtils::getValue($values[$iTags['title'][0]]['value']);
-		$art['allow_com'] = plxUtils::getValue($values[$iTags['allow_com'][0]]['value']);
-		$art['template'] = plxUtils::getValue($values[$iTags['template'][0]]['value'],'article.php');
-		$art['chapo'] = plxUtils::getValue($values[$iTags['chapo'][0]]['value']);
-		$art['content'] = plxUtils::getValue($values[$iTags['content'][0]]['value']);
-		$art['tags'] = plxUtils::getValue($values[ $iTags['tags'][0] ]['value']);
-		$meta_description = plxUtils::getValue($iTags['meta_description'][0]);
-		$art['meta_description'] = plxUtils::getValue($values[$meta_description]['value']);
-		$meta_keywords = plxUtils::getValue($iTags['meta_keywords'][0]);
-		$art['meta_keywords'] = plxUtils::getValue($values[$meta_keywords]['value']);
-		$art['title_htmltag'] = isset($iTags['title_htmltag']) ? plxUtils::getValue($values[$iTags['title_htmltag'][0]]['value']) : '';
-		$art['thumbnail'] = isset($iTags['thumbnail']) ? plxUtils::getValue($values[$iTags['thumbnail'][0]]['value']) : '';
-		$art['thumbnail_title'] = isset($iTags['thumbnail_title']) ? plxUtils::getValue($values[$iTags['thumbnail_title'][0]]['value']) : '';
-		$art['thumbnail_alt'] = isset($iTags['thumbnail_alt']) ? plxUtils::getValue($values[$iTags['thumbnail_alt'][0]]['value']) : '';
 		# Informations obtenues en analysant le nom du fichier
-		$art['filename'] = $filename;
 		$tmp = $this->artInfoFromFilename($filename);
-		$art['numero'] = $tmp['artId'];
-		$art['author'] = $tmp['usrId'];
-		$art['categorie'] = $tmp['catId'];
-		$art['url'] = $tmp['artUrl'];
-		$art['date'] = $tmp['artDate'];
-		$art['nb_com'] = $this->getNbCommentaires('#^'.$art['numero'].'.\d{10}.\d+.xml$#');
-		$art['date_creation'] = isset($iTags['date_creation']) ? plxUtils::getValue($values[$iTags['date_creation'][0]]['value']) : $art['date'];
-		$art['date_update'] = isset($iTags['date_update']) ? plxUtils::getValue($values[$iTags['date_update'][0]]['value']) : $art['date'];
-		# Hook plugins
-		eval($this->plxPlugins->callHook('plxMotorParseArticle'));
-		# On retourne le tableau
-		return $art;
+		if(!empty($tmp)) {
+			# Mise en place du parseur XML
+			$data = implode('',file($filename));
+			$parser = xml_parser_create(PLX_CHARSET);
+			xml_parser_set_option($parser,XML_OPTION_CASE_FOLDING,0);
+			xml_parser_set_option($parser,XML_OPTION_SKIP_WHITE,0);
+			xml_parse_into_struct($parser,$data,$values,$iTags);
+			xml_parser_free($parser);
+
+			$meta_description = plxUtils::getValue($iTags['meta_description'][0]);
+			$meta_keywords = plxUtils::getValue($iTags['meta_keywords'][0]);
+			$art = array(
+				'filename'		=> $filename,
+				# Recuperation des valeurs de nos champs XML
+				'title'				=> plxUtils::getValue($values[$iTags['title'][0]]['value']),
+				'allow_com'			=> plxUtils::getValue($values[$iTags['allow_com'][0]]['value']),
+				'template'			=> plxUtils::getValue($values[$iTags['template'][0]]['value'], 'article.php'),
+				'chapo'				=> plxUtils::getValue($values[$iTags['chapo'][0]]['value']),
+				'content'			=> plxUtils::getValue($values[$iTags['content'][0]]['value']),
+				'tags'				=> plxUtils::getValue($values[ $iTags['tags'][0] ]['value']),
+				'meta_description'	=> plxUtils::getValue($values[$meta_description]['value']),
+				'meta_keywords'		=> plxUtils::getValue($values[$meta_keywords]['value']),
+				'title_htmltag'		=> plxUtils::getValue($values[$iTags['title_htmltag'][0]]['value']),
+				'thumbnail'			=> plxUtils::getValue($values[$iTags['thumbnail'][0]]['value']),
+				'thumbnail_title'	=> plxUtils::getValue($values[$iTags['thumbnail_title'][0]]['value']),
+				'thumbnail_alt'		=> plxUtils::getValue($values[$iTags['thumbnail_alt'][0]]['value']),
+				'numero'			=> $tmp['artId'],
+				'author'			=> $tmp['usrId'],
+				'categorie'			=> $tmp['catId'],
+				'url'				=> $tmp['artUrl'],
+				'date'				=> $tmp['artDate'],
+				'nb_com'			=> $this->getNbCommentaires('#^' . $tmp['artId'] . '.\d{10}.\d+.xml$#'),
+				'date_creation'		=> plxUtils::getValue($values[$iTags['date_creation'][0]]['value'], $tmp['artDate']),
+				'date_update'		=> plxUtils::getValue($values[$iTags['date_update'][0]]['value'], $tmp['artDate']),
+			);
+
+			# Hook plugins
+			eval($this->plxPlugins->callHook('plxMotorParseArticle'));
+
+			# On retourne le tableau
+			return $art;
+		} else {
+			# le nom du fichier article est incorrect !!
+			return false;
+		}
 	}
 
 	/**

--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -541,7 +541,7 @@ class plxUtils {
 		$clean_url = preg_replace('@[\s' . $replace . ']+@', $replace, $clean_url);
 
 		// remove non-alphanumeric character
-		$clean_url = trim(preg_replace('@[^\w\.-]+@', '', $clean_url), '-');
+		$clean_url = trim(preg_replace('@[^\w-]+@', '', $clean_url), '-');
 
 		if($lower) {
 			$clean_url = strtolower($clean_url);


### PR DESCRIPTION
Voir discussion sur le forum :
https://forum.pluxml.org/discussion/6757/resolu-jai-un-article-fantome-en-admin#latest

---

Fix plxUtils::urlify

Pas de point dans une URL (voir RFC 3986 ou urlencode() en PHP)

Fix plxMotor::parseArticle():
On controle d'abord que le nom du fichier est valide. On retourne false si echec

Fix plxMotor::getArticles():
On controle que plxMotor::parseArticle retourne bien un article
Si ok, on le pousse à la fin du tableau ( pas de tableau associatif ) pour que les indices numériques se suivent même si l'analyse d'un article à échoué


