### PR TITLE
Plxshow arttags 201107

### DIFF
--- a/core/lang/en/admin.php
+++ b/core/lang/en/admin.php
@@ -529,5 +529,5 @@ const L_THEMES_TITLE = 'Manage themes';
 const L_HELP = 'Help';
 const L_HELP_TITLE = 'See help';
 const L_BACK_TO_THEMES = 'Back to themes';
-const L_CONFIG_THEME_UPDATE = 'Select this theme'
+const L_CONFIG_THEME_UPDATE = 'Select this theme';
 ?>


### PR DESCRIPTION
Fix: plxShow::artTags gère les tags avec les lettres accentuées
Emploi plxUtils::urlify() pour les tags de l'article
Optimisation de l'emploi de array_map();

Fix: Corrige Bug si aucune catégorie connue dans plxShow::artCat