### PR TITLE
Fix valeur par défaut pour allow_com dans plxMotor::parseArticle()

### DIFF
--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -704,7 +704,7 @@ class plxMotor {
                 'filename'		=> $filename,
                 # Recuperation des valeurs de nos champs XML
                 'title'				=> plxUtils::getValue($values[$iTags['title'][0]]['value']),
-                'allow_com'			=> plxUtils::getValue($values[$iTags['allow_com'][0]]['value']),
+                'allow_com'			=> plxUtils::getValue($values[$iTags['allow_com'][0]]['value'], 0),
                 'template'			=> plxUtils::getValue($values[$iTags['template'][0]]['value'], 'article.php'),
                 'chapo'				=> plxUtils::getValue($values[$iTags['chapo'][0]]['value']),
                 'content'			=> plxUtils::getValue($values[$iTags['content'][0]]['value']),

--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -31,7 +31,7 @@ class plxUtils {
 	 * @return	string		valeur de la variable ou valeur par défaut passée en paramètre
 	*/
 	public static function getValue(&$var, $default='') {
-		return (isset($var) ? (!empty($var) ? $var : $default) : $default) ;
+		return isset($var) ? $var : $default;
 	}
 
 	/**


### PR DESCRIPTION
Refacto plxUtils::getValue()  (conflit 0 et empty())

Voir https://forum.pluxml.org/discussion/6925/commentaire-allow-com-passe-a-1
Dans les versions précèdentes de PluXml pour allow_com d'un article on  stocker "oui " ou "non" comme valeur. 
En utilisant "1" ou "0" comme valeurs, on révèle un bug dans plxMotor::parseArticle() et dans plxUtils::getValue() :
par de valeur par defaut pour allow_com et utilisation de $defaut si $var == '0' (PB avec empty())