### PR TITLE
Install sample, 1st art missing thumb alt & title

### DIFF
--- a/install.php
+++ b/install.php
@@ -196,6 +196,8 @@ function install($content, $config) {
 	<date_creation><![CDATA['.date('YmdHi').']]></date_creation>
 	<date_update><![CDATA['.date('YmdHi').']]></date_update>
 	<thumbnail><![CDATA[core/admin/theme/images/pluxml.png]]></thumbnail>
+	<thumbnail_alt><![CDATA[PluXml logo]]></thumbnail_alt>
+	<thumbnail_title><![CDATA[PluXml]]></thumbnail_title>
 </document>';
 		plxUtils::write($xml,PLX_ROOT.$config['racine_articles'].'0001.001.001.'.date('YmdHi').'.'.L_DEFAULT_ARTICLE_URL.'.xml');
 	}


### PR DESCRIPTION
Si l'on choisit d'installer avec les données d'exemples, et après s'être connecté a l'admin (et que les notices PHP soient affichées) se produit sur toutes les page du backend un affichage disgracieux tant que le premier article subsiste en l'état.

Pour corrigé, il suffit d'éditer le premier article pour que les attributs "alt" et "title" soient ajouté au fichier ou supprimer l'article ;-)