### PR TITLE
Fix use of uasort() for plxAdmin

### DIFF
--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -645,7 +645,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 				}
 			}
 			# On va trier les clés selon l'ordre choisi
-			if(sizeof($this->aCats)>0) uasort($this->aCats, function($a, $b){return $a["ordre"]>$b["ordre"];});
+			if(sizeof($this->aCats) > 1) uasort($this->aCats, function($a, $b) { return intval($a['ordre']) - intval($b['ordre']); } );
 		}
 		# sauvegarde
 		if($action) {
@@ -777,8 +777,9 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 				}
 			}
 			# On va trier les clés selon l'ordre choisi
-			if(sizeof($this->aStats)>0)
-				uasort($this->aStats, function($a, $b){return $a["ordre"]>$b["ordre"];});
+			if(sizeof($this->aStats) > 1) {
+				uasort($this->aStats, function($a, $b) { return intval($a['ordre']) - intval($b['ordre']); } );
+			}
 		}
 		# sauvegarde
 		if($action) {


### PR DESCRIPTION
La fonction de callback de uasort() doit retourner une valeur numérique et non une valeur booléenne !!
voir https://www.php.net/manual/fr/function.usort.php