### PR TITLE
Checks if template exists in plxMotor::prechauffage

### DIFF
--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -251,6 +251,12 @@ class plxMotor {
 			$this->error404(L_ERR_PAGE_NOT_FOUND);
 		}
 
+		# On vérifie l'existence du template
+		$filename = $this->style . '/' . $this->template;
+		if(!file_exists(PLX_ROOT . $this->aConf['racine_themes'] . $filename)) {
+			$this->error404(L_ERR_FILE_NOTFOUND . ' ( <i>' . $filename . '</i> )');
+		}
+
 		# Hook plugins
 		eval($this->plxPlugins->callHook('plxMotorPreChauffageEnd'));
 	}


### PR DESCRIPTION
En changeant de thème, il peut arriver qu'un template soit manquant.
On reçoit alors une notification en text/plain sans aucun lien pour revenir à la page d'accueil.
Ici on affiche la notification dans une page HTML avec menu et sidebar comme pour les articles inexistants
C'est moins perturbant pour un newbie.