### PR TITLE
Update class.plx.motor.php

### DIFF
--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -682,7 +682,7 @@ class plxMotor {
 					return in_array($item, $ids);
 				}
 			);
-			if(count($artCats) == 1 and key($artCats) == 'draft') {
+			if(count($artCats) == 1 and array_values($artCats)[0] == 'draft') {
 				$artCats[] = '000';
 			}
 			return array(

--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -682,7 +682,7 @@ class plxMotor {
 					return in_array($item, $ids);
 				}
 			);
-			if(count($artCats) == 1 and $artCats[0] == 'draft') {
+			if(count($artCats) == 1 and key($artCats) == 'draft') {
 				$artCats[] = '000';
 			}
 			return array(

--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -682,7 +682,7 @@ class plxMotor {
 					return in_array($item, $ids);
 				}
 			);
-			if(count($artCats) == 1 and array_values($artCats)[0] == 'draft') {
+			if(count($artCats) == 1 and  in_array('draft', $artCats)) {
 				$artCats[] = '000';
 			}
 			return array(


### PR DESCRIPTION
modif ligne 685 : recherche sur la premiere(et unique) clé au lieu de faire une recherche sur une clé nommée

Il peut parfois arrivé que la clé testée n'existe pas car sa  valeur peut differer de '0' . 
En utilisant `key($array)` sur un tableau d'une seule valeur, on peut tester la valeur de son unique  clé sans en connaitre le nom. 