### PR TITLE
Nouvelle fonction plxUtils::sanitizePhp()

### DIFF
--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -876,7 +876,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 			# Génération du nom du fichier de la page statique
 			$filename = PLX_ROOT.$this->aConf['racine_statiques'].$content['id'].'.'.$this->aStats[ $content['id'] ]['url'].'.php';
 			# On écrit le fichier
-			if(plxUtils::write($content['content'],$filename))
+			if(plxUtils::write(plxUtils::sanitizePhp($content['content']),$filename))
 				return plxMsg::Info(L_SAVE_SUCCESSFUL);
 			else
 				return plxMsg::Error(L_SAVE_ERR.' '.$filename);

--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -864,7 +864,8 @@ class plxUtils {
 	 **/
 	public static function cdataCheck($str) {
 		$str = str_ireplace('!CDATA', '&#33;CDATA', $str);
-		return str_replace(']]>', ']]&gt;', $str);
+        $str = str_replace(']]>', ']]&gt;', $str);
+		return self::sanitizePhp($str);
 	}
 
 	/**
@@ -1494,4 +1495,25 @@ EOT;
 		}
 	}
 
+    /**
+     * Remove Php opening and closing tags
+     *
+     * Deprecated !
+     * @param String $content
+     * @return array|string|string[]
+     * @author Pedro "P3ter" CADETE, Moritz Huppert
+     */
+    public static function sanitizePhpTags(String $content) {
+        return str_ireplace(array("<?php","<?", "?>"), "", $content);;
+    }
+
+    /**
+     * Remove critical functions from PHP
+     * @param String $content
+     * @return String
+     * @author Jean-Pierre Pourrez aka bazooka07
+     **/
+    public static function sanitizePhp(String $content) {
+		return preg_replace('#\b(fsockopen|proc_open|system|exec|chroot|shell_exec|socket\w*)\b\([^)]*?\)\s*;#', '/* $1() not allowed here */;' . PHP_EOL, $content);
+	}
 }


### PR DESCRIPTION
Fix issue #558 
Suppression des fonctions critiques suivantes dans le contenu des pages statiques :
fsockopen
proc_open
system
exec
chroot
shell_exec
socket\w*