### PR TITLE
PlxUtils::testModRewrite 220824

### DIFF
--- a/core/admin/parametres_avances.php
+++ b/core/admin/parametres_avances.php
@@ -50,7 +50,8 @@ include __DIR__ .'/top.php';
 					<?php } ?>
 				<?php else: ?>
 					<?php echo L_MODREWRITE_NOT_AVAILABLE ?>
-				<?php endif; ?>
+					<input type="hidden" name="urlrewriting" value="0" />
+ 				<?php endif; ?>
 			</div>
 		</div>
 		<div class="grid">

--- a/core/admin/prepend.php
+++ b/core/admin/prepend.php
@@ -1,6 +1,8 @@
 <?php
 const PLX_ROOT = '../../';
 const PLX_CORE = PLX_ROOT .'core/';
+const HTACCESS_FILE = PLX_ROOT . '.htaccess';
+
 const SESSION_LIFETIME = 7200;
 
 include PLX_ROOT.'config.php';

--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -162,6 +162,10 @@ class plxAdmin extends plxMotor {
 	 **/
 	public function htaccess($action, $url) {
 
+		if(!defined('HTACCESS_FILE')) {
+			return;
+		}
+
 		$capture = '';
 		$base = parse_url($url);
 
@@ -181,9 +185,7 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 # END -- Pluxml
 ';
 
-		$htaccess = '';
-		if(is_file(PLX_ROOT.'.htaccess'))
-			$htaccess = file_get_contents(PLX_ROOT.'.htaccess');
+		$htaccess = is_file(HTACCESS_FILE) ? file_get_contents(HTACCESS_FILE) : '';
 
 		switch($action) {
 			case '0': # désactivation
@@ -200,13 +202,13 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 
 		# Hook plugins
 		eval($this->plxPlugins->callHook('plxAdminHtaccess'));
+
 		# On écrit le fichier .htaccess à la racine de PluXml
 		$htaccess = trim($htaccess);
-		if($htaccess=='' AND is_file(PLX_ROOT.'.htaccess')) {
-			unlink(PLX_ROOT.'.htaccess');
-			return true;
+		if($htaccess=='' AND is_file(HTACCESS_FILE)) {
+			return unlink(HTACCESS_FILE);
 		} else {
-			return plxUtils::write($htaccess, PLX_ROOT.'.htaccess');
+			return plxUtils::write($htaccess, HTACCESS_FILE);
 		}
 
 	}

--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -404,6 +404,10 @@ class plxMotor {
 		$this->aConf['medias'] = isset($this->aConf['medias']) ? $this->aConf['medias'] : 'data/images/';
 		if(!defined('PLX_PLUGINS')) define('PLX_PLUGINS', PLX_ROOT . $this->aConf['racine_plugins']);
 		if(!defined('PLX_PLUGINS_CSS_PATH')) define('PLX_PLUGINS_CSS_PATH', preg_replace('@^([^/]+/).*@', '$1', $this->aConf['medias']));
+		# On vérifie que le module Rewrite d'Apache est reconnu. Sinon on bloque la réécriture d'URL
+		if (plxUtils::testModRewrite(false) === false or $this->aConf['urlrewriting'] != 1) {
+			$this->aConf['urlrewriting'] = '0';
+		}
 	}
 
 	/**

--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -336,28 +336,39 @@ class plxUtils {
 	 * @param	io			affiche à l'écran le résultat du test si à VRAI
 	 * @param	format		format d'affichage
 	 * @return	boolean		retourne vrai si le module apache mod_rewrite est disponible
-	 * @author	Stephane F
+	 * @author	Stephane F, Jean-Pierre Pourrez "bazooka07"
 	 **/
-	public static function testModRewrite($io=true, $format="<li><span style=\"color:#color\">#symbol #message</span></li>\n") {
+	public static function testModRewrite($io=true, $format='<li><span style="color:#color">#symbol #message</span></li>' . PHP_EOL) {
 
-		if(function_exists('apache_get_modules')) {
-			$test = in_array("mod_rewrite", apache_get_modules());
-			if($io==true) {
-				if($test) {
-					$output = str_replace('#color', 'green', $format);
-					$output = str_replace('#symbol', '&#10004;', $output);
-					$output = str_replace('#message', L_MODREWRITE_AVAILABLE, $output);
-					echo $output;
-				} else {
-					$output = str_replace('#color', 'red', $format);
-					$output = str_replace('#symbol', '&#10007;', $output);
-					$output = str_replace('#message', L_MODREWRITE_NOT_AVAILABLE, $output);
-					echo $output;
-				}
-			}
-			return $test;
+		if ($io == true) {
+			# Rien n'est acquis. Soyons pessimistes
+			$replaces = array(
+				'#color'	=> 'red',
+				'#symbol'	=> '&#10007;',
+				'#message'	=> L_MODREWRITE_NOT_AVAILABLE,
+			);
 		}
-		else return true;
+
+		if (function_exists('apache_get_modules')) {
+			$test = in_array('mod_rewrite', apache_get_modules());
+			if ($io != true) {
+				return $test;
+			}
+			if ($test) {
+				# Success !
+				$replaces = array(
+					'#color'	=> 'green',
+					'#symbol'	=> '&#10004;',
+					'#message'	=> L_MODREWRITE_AVAILABLE,
+				);
+			}
+		} else {
+			if ($io != true) {
+				return false;
+			}
+		}
+
+		echo strtr($format, $replaces);
 	}
 
 	/**


### PR DESCRIPTION
Refacto plxUtils::testModRewrite()
Corrige la réponse de la fonction si on ne détecte pas le module Rewrite de Apache (pas de serveur Apache, function apache_get_modules non disponible, module non chargé, etc...) quelque soit la valeur du paramètre $io
Force la valeur de $plxMotor->aConf['urlrewriting'] à 0 si module non détecté ou différent de 1
Met à jour le fichier .htaccess que si cette valeur est modifiée dans le back-office