### PR TITLE
Suppression testModRewrite() dans plxAdmin::editConfiguration()

### DIFF
--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -91,10 +91,6 @@ class plxAdmin extends plxMotor {
 	 **/
 	public function editConfiguration($plxConfig, $content) {
 
-		if(!plxUtils::testModRewrite(false) or !isset($content['urlrewriting'])) {
-			$content['urlrewriting'] = '0';
-		}
-
 		# Sauvegarde de la valeur initiale
 		$urlrewriting = $plxConfig['urlrewriting'];
 


### PR DESCRIPTION
plxUtils::testModRewrite() ne fonctionne pas avec un serveur PHP-FPM