### PR TITLE
cocher/decocher page statique en acceuil    Update class.plx.admin.php

### DIFF
--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -199,7 +199,7 @@ class plxAdmin extends plxMotor {
 					continue;
 				}
 
-			} elseif($k == 'homestatic') {
+			} elseif($k == 'homeStatic') {
 				if(
 					empty(trim($v)) or
 					!preg_match('#^\d{3,4}$#', $v)


### PR DESCRIPTION
Impossible de décocher une page statique mise en acceuil

 fix : typo ligne 202 homestatic => réecrit en homeStatic