### PR TITLE
PHP8.2 : utf8_[en|de]code deprecated

### DIFF
--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -895,7 +895,7 @@ class plxUtils {
 			$length = sizeof($content) < $length ? sizeof($content) : $length;
 			return implode(' ',array_slice($content,0,$length)).$add_text;
 		} else { # On coupe la chaine en comptant le nombre de caractères
-			return strlen($str) > $length ? utf8_decode(substr(utf8_encode($str), 0, $length)).$add_text : $str;
+			return strlen($str) > $length ? substr($str, 0, $length) . $add_text : $str;
 		}
 	}
 

--- a/install.php
+++ b/install.php
@@ -43,14 +43,14 @@ loadLang(PLX_CORE.'lang/'.$lang.'/core.php');
 # On vérifie la version minimale de PHP
 if(version_compare(PHP_VERSION, PHP_VERSION_MIN, '<')){
 	header('Content-Type: text/plain charset=UTF-8');
-	echo utf8_decode(L_WRONG_PHP_VERSION);
+	echo L_WRONG_PHP_VERSION;
 	exit;
 }
 
 # On vérifie que PluXml n'est pas déjà installé
 if(file_exists(path('XMLFILE_PARAMETERS'))) {
 	header('Content-Type: text/plain charset=UTF-8');
-	echo utf8_decode(L_ERR_PLUXML_ALREADY_INSTALLED);
+	echo L_ERR_PLUXML_ALREADY_INSTALLED;
 	exit;
 }
 


### PR DESCRIPTION
Il est probable et plus simple de ne rien décoder/encoder maintenant que PluXml est en utf8 :)
Reste aux thèmes d’êtres en utf8 pour que les utilisateurs enregistrent leurs commentaires au bon format.
Scope : les 5 derniers commentaires de la sidebar coté public

https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated