### PR TITLE
Fix auth redirection perpetuelle

### DIFF
--- a/core/admin/prepend.php
+++ b/core/admin/prepend.php
@@ -24,7 +24,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') $_POST = plxUtils::unSlash($_POST);
 $plxAdmin = plxAdmin::getInstance();
 $lang = $plxAdmin->aConf['default_lang'];
 
-if(isset($_SESSION['user'])) {
+if(isset($_SESSION['user']) AND !defined('PLX_AUTHPAGE')) {
 	# Si utilisateur désactivé ou supprimé par un admin, hors page de login. (!PLX_AUTHPAGE)
 	if(
 		!array_key_exists($_SESSION['user'], $plxAdmin->aUsers) or

--- a/core/admin/prepend.php
+++ b/core/admin/prepend.php
@@ -5,7 +5,8 @@ const PLX_CORE = PLX_ROOT . 'core/';
 const SESSION_DOMAIN = __DIR__ ;
 const SESSION_LIFETIME = 7200; // 2 hours
 
-const DEL_USER_QUERY = 'auth.php\?d=1';
+const DEL_USER_QUERY = 'auth.php?d=1';
+const DEL_USER_REGEX = 'auth.php\?d=1';
 
 include '../lib/config.php';
 
@@ -36,7 +37,7 @@ $lang = $plxAdmin->aConf['default_lang'];
 
 if(
 	isset($_SESSION['user']) and
-	!preg_match('#\b' . DEL_USER_QUERY . '$#', $_SERVER['REQUEST_URI']) // for avoiding infinite loops
+	!preg_match('#\b' . DEL_USER_REGEX . '$#', $_SERVER['REQUEST_URI']) // for avoiding infinite loops
 ) {
 	# Si utilisateur désactivé ou supprimé par un admin, hors page de login. (!PLX_AUTHPAGE)
 	if(


### PR DESCRIPTION
Pour reproduire : 
En local et aucun hôte virtuel avec 2 instances de PluXml comme localhost/plx1 ET localhost/plx2
1-Se connecter a plx1 avec un utilisateur inexistant/supprimé au plx2 (important)
2-nouvel onglet, aller a localhost/plx2/core/admin/ 
Résultat "La page n’est pas redirigée correctement"
Il boucle sur auth.php?d=1

Se code me rappelle quelque chose :)