### PR TITLE
Fix SUBSCRIBER auth redirection

### DIFF
--- a/core/admin/auth.php
+++ b/core/admin/auth.php
@@ -109,7 +109,7 @@ if ($_SESSION['maxtry']['counter'] >= 0 and !empty($_POST['login']) and !empty($
 		unset($_SESSION['maxtry']);
 		if($plxAdmin->nbArticles('all', ($_SESSION['profil'] < PROFIL_WRITER) ? '\d{3}' : $_SESSION['user']) == 0) {
 			# nouvel article
-			$redirect .= $_SESSION['profil'] > PROFIL_WRITER  ? 'profil.php' : 'article.php';
+			$redirect = $_SESSION['profil'] > PROFIL_WRITER  ? 'profil.php' : 'article.php';
 		}
 		header('Location: ' . htmlentities($redirect));
 		exit;


### PR DESCRIPTION
Pour Reproduire:
1-Connecté en tant qu'admin sur une page de paramètre
2-Clic droit sur le lien déconnexion pour l'ouvrir ds un nouvel onglet (et le fermer)
3-Recharger l'onglet admin pour être rediriger vers auth.php?p=param.php
4-Se connecté avec le profil d'un **abonné**
5-PluXml veut accéder a la page avec param.php**profil.php** comme ceci `parametres_users.phpprofil.php`

Ps : peut-être ajouter un `plxAdmin->racine . 'core/admin/' . ` avant profil|article.php de `$redirect` mais ça fonctionne bien ainsi, KISS