### PR TITLE
Fix author list : subscriber is writer : admin/article.php

### DIFF
--- a/core/admin/article.php
+++ b/core/admin/article.php
@@ -249,7 +249,7 @@ foreach($plxAdmin->aUsers as $_userid => $_user) {
 			$_users[L_PROFIL_MODERATOR][$_userid] = plxUtils::strCheck($_user['name']);
 		elseif($_user['profil']==PROFIL_EDITOR)
 			$_users[L_PROFIL_EDITOR][$_userid] = plxUtils::strCheck($_user['name']);
-		else
+		elseif($_user['profil']==PROFIL_WRITER)
 			$_users[L_PROFIL_WRITER][$_userid] = plxUtils::strCheck($_user['name']);
 	}
 }


### PR DESCRIPTION
Corrige le fait que les abonnés soient listés en tant que Rédacteur dans le sélecteur de l'auteur de l'article.
Rejoint le PR #689 et évite une confusion.