### PR TITLE
Fix update/index.php : Constants already defined et +

### DIFF
--- a/update/index.php
+++ b/update/index.php
@@ -12,17 +12,7 @@ if(!file_exists(path('XMLFILE_PARAMETERS'))) {
 	exit;
 }
 
-# On inclut les librairies nécessaires
-include(PLX_CORE.'lib/class.plx.date.php');
-include(PLX_CORE.'lib/class.plx.glob.php');
-include(PLX_CORE.'lib/class.plx.utils.php');
-include(PLX_CORE.'lib/class.plx.msg.php');
-include(PLX_CORE.'lib/class.plx.record.php');
-include(PLX_CORE.'lib/class.plx.motor.php');
-include(PLX_CORE.'lib/class.plx.admin.php');
-include(PLX_CORE.'lib/class.plx.encrypt.php');
-include(PLX_CORE.'lib/class.plx.plugins.php');
-include(PLX_CORE.'lib/class.plx.token.php');
+# On inclut les librairies nécessaires pour la MAJ
 include(PLX_ROOT.'update/versions.php');
 include(PLX_ROOT.'update/class.plx.updater.php');
 

--- a/update/index.php
+++ b/update/index.php
@@ -39,7 +39,7 @@ loadLang(PLX_CORE.'lang/'.$lang.'/update.php');
 # On vérifie la version minimale de PHP
 if(version_compare(PHP_VERSION, PHP_VERSION_MIN, '<')){
 	header('Content-Type: text/plain charset=UTF-8');
-	echo utf8_decode(L_WRONG_PHP_VERSION);
+	echo L_WRONG_PHP_VERSION;
 	exit;
 }
 
@@ -51,8 +51,6 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 # Création de l'objet principal et lancement du traitement
 $plxUpdater = new plxUpdater($versions);
 
-?>
-<?php
 plxUtils::cleanHeaders();
 session_set_cookie_params(0, "/", $_SERVER['SERVER_NAME'], isset($_SERVER["HTTPS"]), true);
 session_start();

--- a/update/index.php
+++ b/update/index.php
@@ -13,8 +13,8 @@ if(!file_exists(path('XMLFILE_PARAMETERS'))) {
 }
 
 # On inclut les librairies nécessaires pour la MAJ
-include(PLX_ROOT.'update/versions.php');
-include(PLX_ROOT.'update/class.plx.updater.php');
+include PLX_ROOT.'update/versions.php';
+include PLX_ROOT.'update/class.plx.updater.php';
 
 # Chargement des langues
 $lang = (!empty($_SERVER['HTTP_ACCEPT_LANGUAGE'])) ? substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2) : DEFAULT_LANG;
@@ -23,6 +23,7 @@ if(!array_key_exists($lang, plxUtils::getLangs())) {
 	$lang = DEFAULT_LANG;
 }
 loadLang(PLX_CORE.'lang/'.$lang.'/core.php');
+loadLang(PLX_CORE.'lang/'.$lang.'/admin.php');
 loadLang(PLX_CORE.'lang/'.$lang.'/update.php');
 
 # On vérifie la version minimale de PHP

--- a/update/index.php
+++ b/update/index.php
@@ -1,7 +1,7 @@
 <?php
 const PLX_ROOT = '../';
 const PLX_CORE = PLX_ROOT . 'core/';
-include(PLX_ROOT.'config.php');
+
 include(PLX_CORE.'lib/config.php');
 
 const PLX_UPDATER = true;

--- a/update/index.php
+++ b/update/index.php
@@ -33,7 +33,6 @@ if(!array_key_exists($lang, plxUtils::getLangs())) {
 	$lang = DEFAULT_LANG;
 }
 loadLang(PLX_CORE.'lang/'.$lang.'/core.php');
-loadLang(PLX_CORE.'lang/'.$lang.'/admin.php');
 loadLang(PLX_CORE.'lang/'.$lang.'/update.php');
 
 # On vérifie la version minimale de PHP


### PR DESCRIPTION
Fix PLX_CONFIG_PATH & L_SAVE_SUCCESSFUL already defined
+php8.2 utf8_decode is deprecated
+classe dèja chargées par lib/config.php

Voulant faire une MAJ depuis des données d'un PluXml v5.2, il a 2 warnings !

Après avoir corrigé le fichier comme ceci,
la MAJ s'est déroulé comme un charme (elle se serait probablement bien déroulé sans) 

![PluXml 5 9RC2 update data from 5 2 : Capture d’écran du 2024-01-11 05-24-37](https://github.com/pluxml/PluXml/assets/1390644/b9990f53-b37a-48b0-84e1-51f1add44476)
