### PR TITLE
Fix plxGlob::validateFormToken() and minor bugs

### DIFF
--- a/core/lib/class.plx.token.php
+++ b/core/lib/class.plx.token.php
@@ -8,7 +8,7 @@
 class plxToken {
 	const TEMPLATE = 'abcdefghijklmnpqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 	const TEMPLATE_LENGTH = 61; // strlen(self::TEMPLATE);
-	const LIFETIME = 3600; // seconds
+	const LIFETIME = 1800; // seconds - See session.gc_maxlifetime in php.ini
 
 	/**
 	 * Méthode qui affiche le champ input contenant le token
@@ -45,14 +45,11 @@ class plxToken {
 				unset($_SESSION['formtoken']);
 				die('Security error : invalid or expired token');
 			}
-			unset($_SESSION['formtoken'][$_POST['token']]);
 
-			// cleanup old tokens
+			// cleanup old tokens. But keep last 2 items for refresh the current HTML page ( Hit F5 key in the navigator )
 			if(!empty($_SESSION['formtoken'])) {
-				foreach($_SESSION['formtoken'] as $token=>$lifetime) {
-					if($lifetime < $limit) {
-						unset($_SESSION['formtoken'][$token]);
-					}
+				while(count($_SESSION['formtoken']) > 2) {
+					$oldTime = array_shift($_SESSION['formtoken']);
 				}
 			}
 		}
@@ -63,10 +60,11 @@ class plxToken {
 	 *
 	 * @param	int		hours before expiration
 	 * @return	string	expiry date
-	 * @author	Pedro "P3ter" CADETE
+	 * @author	Pedro "P3ter" CADETE, Jean-Pierre Pourrez @bazooka07
 	 */
 	public static function generateTokenExperyDate($hours = 24) {
-		return date('YmdHis', mktime(date('H')+$hours, date('i'), date('s'), date('m'), date('d'), date('Y')));
+		// return date('YmdHis', mktime(date('H')+$hours, date('i'), date('s'), date('m'), date('d'), date('Y')));
+		return date('YmdHis', time() + $hours * 3600);
 	}
 
 }


### PR DESCRIPTION
Fix  'Security error : invalid or expired token' error when a form is reloaded (F5 key in navigator)
Fix plxGlob::LIFETIME to a reasonable value vs php.ini
Refacto plxGlob::generateTokenExperyDate()