### PR TITLE
Feat : Admin dynamic required fields and little more

### DIFF
--- a/core/admin/article.php
+++ b/core/admin/article.php
@@ -325,8 +325,8 @@ if($_SESSION['profil']>PROFIL_MODERATOR AND $plxAdmin->aConf['mod_art']) {
 				<div class="grid">
 					<div class="col sml-12">
 						<?php plxUtils::printInput('artId',$artId,'hidden'); ?>
-						<label for="id_title"><?= L_ARTICLE_TITLE ?>&nbsp;:</label>
-						<?php plxUtils::printInput('title',plxUtils::strCheck($title),'text','42-255',false,'full-width'); ?>
+						<label for="id_title" class="required"><?= L_ARTICLE_TITLE ?>&nbsp;:</label>
+						<?php plxUtils::printInput('title',plxUtils::strCheck($title),'text','42-255',false,'full-width',L_ARTICLE_TITLE,'',true); ?>
 					</div>
 				</div>
 				<div class="grid">
@@ -349,14 +349,14 @@ if(!empty($artId) AND $artId!='0000') {
 						<input class="toggler" type="checkbox" id="toggler_chapo"<?= (empty($_GET['a']) || ! empty(trim($chapo))) ? ' checked' : ''; ?> />
 						<label for="toggler_chapo"><?= L_HEADLINE_FIELD;?> : <span><?= L_ARTICLE_CHAPO_HIDE;?></span><span><?= L_ARTICLE_CHAPO_DISPLAY;?></span></label>
 						<div>
-							<?php plxUtils::printArea('chapo',plxUtils::strCheck($chapo),0,8); ?>
+							<?php plxUtils::printArea('chapo',plxUtils::strCheck($chapo),0,8,false,'full-width','placeholder=" "'); ?>
 						</div>
 					</div>
 				</div>
 				<div class="grid">
 					<div class="col sml-12">
 						<label for="id_content"><?= L_CONTENT_FIELD ?>&nbsp;:</label>
-						<?php plxUtils::printArea('content',plxUtils::strCheck($content),0,20); ?>
+						<?php plxUtils::printArea('content',plxUtils::strCheck($content),0,20,false,'full-width','placeholder=" "'); ?>
 					</div>
 				</div>
 			</fieldset>
@@ -441,12 +441,12 @@ else
 				</div>
 				<div class="grid">
 					<div class="col sml-12">
-						<label><?= L_ARTICLE_DATE ?>&nbsp;:</label>
+						<label class="required"><?= L_ARTICLE_DATE ?>&nbsp;:</label>
 						<div class="inline-form publication">
-							<?php plxUtils::printInput('date_publication_day',$date['day'],'text','2-2',false,'day'); ?>
-							<?php plxUtils::printInput('date_publication_month',$date['month'],'text','2-2',false,'month'); ?>
-							<?php plxUtils::printInput('date_publication_year',$date['year'],'text','2-4',false,'year'); ?>
-							<?php plxUtils::printInput('date_publication_time',$date['time'],'text','2-5',false,'time'); ?>
+							<?php plxUtils::printInput('date_publication_day',$date['day'],'text','2-2',false,'day',date('d'),'pattern="\d{2}"',true); ?>
+							<?php plxUtils::printInput('date_publication_month',$date['month'],'text','2-2',false,'month',date('m'),'pattern="\d{2}"',true); ?>
+							<?php plxUtils::printInput('date_publication_year',$date['year'],'text','2-4',false,'year',date('Y'),'pattern="\d{4}"',true); ?>
+							<?php plxUtils::printInput('date_publication_time',$date['time'],'text','2-5',false,'time',date('H:m'),'pattern="\d{2}:\d{2}"',true); ?>
 							<a class="ico_cal" href="javascript:void(0)" onclick="dateNow('date_publication', <?= date('Z') ?>); return false;" title="<?php L_NOW; ?>">
 								<img src="theme/images/date.png" alt="calendar" />
 							</a>
@@ -455,12 +455,12 @@ else
 				</div>
 			<div class="grid">
 				<div class="col sml-12">
-					<label><?= L_DATE_CREATION ?>&nbsp;:</label>
+					<label class="required"><?= L_DATE_CREATION ?>&nbsp;:</label>
 					<div class="inline-form creation">
-						<?php plxUtils::printInput('date_creation_day',$date_creation['day'],'text','2-2',false,'day'); ?>
-						<?php plxUtils::printInput('date_creation_month',$date_creation['month'],'text','2-2',false,'month'); ?>
-						<?php plxUtils::printInput('date_creation_year',$date_creation['year'],'text','2-4',false,'year'); ?>
-						<?php plxUtils::printInput('date_creation_time',$date_creation['time'],'text','2-5',false,'time'); ?>
+						<?php plxUtils::printInput('date_creation_day',$date_creation['day'],'text','2-2',false,'day',date('d'),'pattern="\d{2}"',true); ?>
+						<?php plxUtils::printInput('date_creation_month',$date_creation['month'],'text','2-2',false,'month',date('m'),'pattern="\d{2}"',true); ?>
+						<?php plxUtils::printInput('date_creation_year',$date_creation['year'],'text','2-4',false,'year',date('Y'),'pattern="\d{4}"',true); ?>
+						<?php plxUtils::printInput('date_creation_time',$date_creation['time'],'text','2-5',false,'time',date('H:m'),'pattern="\d{2}:\d{2}"',true); ?>
 						<a class="ico_cal" href="javascript:void(0)" onclick="dateNow('date_creation', <?= date('Z') ?>); return false;" title="<?= L_NOW ?>">
 							<img src="theme/images/date.png" alt="calendar" />
 						</a>
@@ -470,12 +470,12 @@ else
 			<div class="grid">
 				<div class="col sml-12">
 					<?php plxUtils::printInput('date_update_old', $date_update_old, 'hidden'); ?>
-					<label><?= L_DATE_UPDATE ?>&nbsp;:</label>
+					<label class="required"><?= L_DATE_UPDATE ?>&nbsp;:</label>
 					<div class="inline-form update">
-						<?php plxUtils::printInput('date_update_day',$date_update['day'],'text','2-2',false,'day'); ?>
-						<?php plxUtils::printInput('date_update_month',$date_update['month'],'text','2-2',false,'month'); ?>
-						<?php plxUtils::printInput('date_update_year',$date_update['year'],'text','2-4',false,'year'); ?>
-						<?php plxUtils::printInput('date_update_time',$date_update['time'],'text','2-5',false,'time'); ?>
+						<?php plxUtils::printInput('date_update_day',$date_update['day'],'text','2-2',false,'day',date('d'),'pattern="\d{2}"',true); ?>
+						<?php plxUtils::printInput('date_update_month',$date_update['month'],'text','2-2',false,'month',date('m'),'pattern="\d{2}"',true); ?>
+						<?php plxUtils::printInput('date_update_year',$date_update['year'],'text','2-4',false,'year',date('Y'),'pattern="\d{4}"',true); ?>
+						<?php plxUtils::printInput('date_update_time',$date_update['time'],'text','2-5',false,'time',date('H:m'),'pattern="\d{2}:\d{2}"',true); ?>
 						<a class="ico_cal" href="javascript:void(0)" onclick="dateNow('date_update', <?= date('Z') ?>); return false;" title="<?= L_NOW ?>">
 							<img src="theme/images/date.png" alt="calendar" />
 						</a>

--- a/core/admin/auth.php
+++ b/core/admin/auth.php
@@ -215,8 +215,8 @@ plxUtils::cleanHeaders();
 <?php
 					break; # End of : case 'lostpassword'
 				case 'changepassword': # Affichage du formulaire de changement de mot passe
-					$lostPasswordToken = $_GET['token'];
-					if ($plxAdmin->verifyLostPasswordToken($lostPasswordToken)) {
+					$lostPasswordToken = filter_has_var(INPUT_GET, 'token')? $_GET['token']: false;# Fix Warning: Undefined array key "token"
+					if ($lostPasswordToken and $plxAdmin->verifyLostPasswordToken($lostPasswordToken)) {
 						# Hook plugins
 						eval($plxAdmin->plxPlugins->callHook('AdminAuthTopChangePassword'));
 ?>
@@ -228,14 +228,17 @@ plxUtils::cleanHeaders();
 								<h1 class="h5 text-center"><strong><?= L_PROFIL_CHANGE_PASSWORD ?></strong></h1>
 								<div class="grid">
 									<div class="col sml-12">
+										<label for="id_password1"><?= L_PROFIL_PASSWORD ?>&nbsp;:</label>
 										<i class="ico icon-lock"></i>
-										<?php plxUtils::printInput('password1', '', 'password', '10-255', false, 'full-width', L_PROFIL_PASSWORD, 'onkeyup="pwdStrength(this.id)"') ?>
+										<?php plxUtils::printInput('password1', '', 'password', '10-255', false, 'full-width', L_PROFIL_PASSWORD, '', true) ?>
 									</div>
 								</div>
 								<div class="grid">
 									<div class="col sml-12">
+										<label for="id_password2"><?= L_PROFIL_CONFIRM_PASSWORD ?><span data-lang="&nbsp;❌|&nbsp;✅"></span>&nbsp;:</label>
 										<i class="ico icon-lock"></i>
-										<?php plxUtils::printInput('password2', '', 'password', '10-255', false, 'full-width', L_PROFIL_CONFIRM_PASSWORD) ?>
+										<?php plxUtils::printInput('password2', '', 'password', '10-255', false, 'full-width', L_PROFIL_CONFIRM_PASSWORD, '', true) ?>
+
 									</div>
 								</div>
 								<div class="grid">

--- a/core/admin/categorie.php
+++ b/core/admin/categorie.php
@@ -53,10 +53,10 @@ include 'top.php';
 <form action="categorie.php" method="post" id="form_category">
 
 	<div class="inline-form action-bar">
-		<h2><?php echo L_EDITCAT_PAGE_TITLE ?> "<?php echo plxUtils::strCheck($plxAdmin->aCats[$id]['name']); ?>"</h2>
-		<p><a class="back" href="categorie.php"><?php echo L_EDITCAT_BACK_TO_PAGE ?></a></p>
-		<?php echo plxToken::getTokenPostMethod() ?>
-		<input type="submit" value="<?php echo L_EDITCAT_UPDATE ?>"/>
+		<h2><?= L_EDITCAT_PAGE_TITLE ?> "<?= plxUtils::strCheck($plxAdmin->aCats[$id]['name']); ?>"</h2>
+		<p><a class="back" href="categorie.php"><?= L_EDITCAT_BACK_TO_PAGE ?></a></p>
+		<?= plxToken::getTokenPostMethod() ?>
+		<input type="submit" value="<?= L_EDITCAT_UPDATE ?>"/>
 	</div>
 
 	<?php eval($plxAdmin->plxPlugins->callHook('AdminCategoryTop')) # Hook Plugins ?>
@@ -65,36 +65,36 @@ include 'top.php';
 		<div class="grid">
 			<div class="col sml-12">
 				<?php plxUtils::printInput('id', $id, 'hidden');?>
-				<label for="id_homepage"><?php echo L_EDITCAT_DISPLAY_HOMEPAGE ?>&nbsp;:</label>
+				<label for="id_homepage"><?= L_EDITCAT_DISPLAY_HOMEPAGE ?>&nbsp;:</label>
 				<?php plxUtils::printSelect('homepage',array('1'=>L_YES,'0'=>L_NO), $plxAdmin->aCats[$id]['homepage']);?>
 			</div>
 		</div>
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_content"><?php echo L_EDITCAT_DESCRIPTION ?>&nbsp;:</label>
-				<?php plxUtils::printArea('content',plxUtils::strCheck($plxAdmin->aCats[$id]['description']),0,8) ?>
+				<label for="id_content"><?= L_EDITCAT_DESCRIPTION ?>&nbsp;:</label>
+				<?php plxUtils::printArea('content',plxUtils::strCheck($plxAdmin->aCats[$id]['description']),0,8,false,'full-width','placeholder=" "') ?>
 			</div>
 		</div>
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_template"><?php echo L_EDITCAT_TEMPLATE ?>&nbsp;:</label>
+				<label for="id_template"><?= L_EDITCAT_TEMPLATE ?>&nbsp;:</label>
 				<?php plxUtils::printSelect('template', $aTemplates, $plxAdmin->aCats[$id]['template']) ?>
 			</div>
 		</div>
 		<div class="grid gridthumb">
 			<div class="col sml-12">
 				<label for="id_thumbnail">
-					<?php echo L_THUMBNAIL ?>&nbsp;:&nbsp;
-					<a title="<?php echo L_THUMBNAIL_SELECTION ?>" id="toggler_thumbnail" href="javascript:void(0)" onclick="mediasManager.openPopup('id_thumbnail', true)" style="outline:none; text-decoration: none">+</a>
+					<?= L_THUMBNAIL ?>&nbsp;:&nbsp;
+					<a title="<?= L_THUMBNAIL_SELECTION ?>" id="toggler_thumbnail" href="javascript:void(0)" onclick="mediasManager.openPopup('id_thumbnail', true)" style="outline:none; text-decoration: none">+</a>
 				</label>
 				<?php plxUtils::printInput('thumbnail',plxUtils::strCheck($plxAdmin->aCats[$id]['thumbnail']),'text','255',false,'full-width','','onkeyup="refreshImg(this.value)"'); ?>
 				<div class="grid" style="padding-top:10px">
 					<div class="col sml-12 lrg-6">
-						<label for="id_thumbnail_title"><?php echo L_THUMBNAIL_TITLE ?>&nbsp;:</label>
+						<label for="id_thumbnail_title"><?= L_THUMBNAIL_TITLE ?>&nbsp;:</label>
 						<?php plxUtils::printInput('thumbnail_title',plxUtils::strCheck($plxAdmin->aCats[$id]['thumbnail_title']),'text','255-255',false,'full-width'); ?>
 					</div>
 					<div class="col sml-12 lrg-6">
-						<label for="id_thumbnail_alt"><?php echo L_THUMBNAIL_ALT ?>&nbsp;:</label>
+						<label for="id_thumbnail_alt"><?= L_THUMBNAIL_ALT ?>&nbsp;:</label>
 						<?php plxUtils::printInput('thumbnail_alt',plxUtils::strCheck($plxAdmin->aCats[$id]['thumbnail_alt']),'text','255-255',false,'full-width'); ?>
 					</div>
 				</div>
@@ -114,21 +114,21 @@ include 'top.php';
 			</div>
 		</div>
 		<div class="grid">
-			<div class="col sml-12">
-				<label for="id_title_htmltag"><?php echo L_EDITCAT_TITLE_HTMLTAG ?>&nbsp;:</label>
-				<?php plxUtils::printInput('title_htmltag',plxUtils::strCheck($plxAdmin->aCats[$id]['title_htmltag']),'text','50-255'); ?>
+			<div class="col sml-12 med-10 lrg-8">
+				<label for="id_title_htmltag"><?= L_EDITCAT_TITLE_HTMLTAG ?>&nbsp;:</label>
+				<?php plxUtils::printInput('title_htmltag',plxUtils::strCheck($plxAdmin->aCats[$id]['title_htmltag']),'text','50-255',false,'full-width'); ?>
 			</div>
 		</div>
 		<div class="grid">
-			<div class="col sml-12">
-				<label for="id_meta_description"><?php echo L_EDITCAT_META_DESCRIPTION ?>&nbsp;:</label>
-				<?php plxUtils::printInput('meta_description',plxUtils::strCheck($plxAdmin->aCats[$id]['meta_description']),'text','50-255') ?>
+			<div class="col sml-12 med-10 lrg-8">
+				<label for="id_meta_description"><?= L_EDITCAT_META_DESCRIPTION ?>&nbsp;:</label>
+				<?php plxUtils::printInput('meta_description',plxUtils::strCheck($plxAdmin->aCats[$id]['meta_description']),'text','50-255',false,'full-width') ?>
 			</div>
 		</div>
 		<div class="grid">
-			<div class="col sml-12">
-				<label for="id_meta_keywords"><?php echo L_EDITCAT_META_KEYWORDS ?>&nbsp;:</label>
-				<?php plxUtils::printInput('meta_keywords',plxUtils::strCheck($plxAdmin->aCats[$id]['meta_keywords']),'text','50-255') ?>
+			<div class="col sml-12 med-10 lrg-8">
+				<label for="id_meta_keywords"><?= L_EDITCAT_META_KEYWORDS ?>&nbsp;:</label>
+				<?php plxUtils::printInput('meta_keywords',plxUtils::strCheck($plxAdmin->aCats[$id]['meta_keywords']),'text','50-255',false,'full-width') ?>
 			</div>
 		</div>
 	</fieldset>

--- a/core/admin/categories.php
+++ b/core/admin/categories.php
@@ -41,13 +41,13 @@ include 'top.php';
 <form action="categories.php" method="post" id="form_categories">
 
 	<div class="inline-form action-bar">
-		<h2><?php echo L_CAT_TITLE ?></h2>
-		<p><a class="back" href="index.php"><?php echo L_BACK_TO_ARTICLES ?></a></p>
+		<h2><?= L_CAT_TITLE ?></h2>
+		<p><a class="back" href="index.php"><?= L_BACK_TO_ARTICLES ?></a></p>
 		<?php plxUtils::printSelect('selection', array( '' => L_FOR_SELECTION, 'delete' => L_DELETE), '', false, 'no-margin', 'id_selection') ?>
-		<input type="submit" name="submit" value="<?php echo L_OK ?>" onclick="return confirmAction(this.form, 'id_selection', 'delete', 'idCategory[]', '<?php echo L_CONFIRM_DELETE ?>')" />
-		<?php echo plxToken::getTokenPostMethod() ?>
+		<input type="submit" name="submit" value="<?= L_OK ?>" onclick="return confirmAction(this.form, 'id_selection', 'delete', 'idCategory[]', '<?= L_CONFIRM_DELETE ?>')" />
+		<?= plxToken::getTokenPostMethod() ?>
 		<span class="sml-hide med-show">&nbsp;&nbsp;&nbsp;</span>
-		<input type="submit" name="update" value="<?php echo L_CAT_APPLY_BUTTON ?>" />
+		<input type="submit" name="update" value="<?= L_CAT_APPLY_BUTTON ?>" />
 	</div>
 
 	<?php eval($plxAdmin->plxPlugins->callHook('AdminCategoriesTop')) # Hook Plugins ?>
@@ -57,14 +57,14 @@ include 'top.php';
 			<thead>
 				<tr>
 					<th class="checkbox"><input type="checkbox" onclick="checkAll(this.form, 'idCategory[]')" /></th>
-					<th><?php echo L_ID ?></th>
-					<th><?php echo L_CAT_LIST_NAME ?></th>
-					<th><?php echo L_CAT_LIST_URL ?></th>
-					<th><?php echo L_CAT_LIST_ACTIVE ?></th>
-					<th><?php echo L_CAT_LIST_SORT ?></th>
-					<th><?php echo L_CAT_LIST_BYPAGE ?></th>
-					<th data-id="order"><?php echo L_CAT_LIST_ORDER ?></th>
-					<th><?php echo L_CAT_LIST_MENU ?></th>
+					<th><?= L_ID ?></th>
+					<th class="required"><?= L_CAT_LIST_NAME ?></th>
+					<th><?= L_CAT_LIST_URL ?></th>
+					<th><?= L_CAT_LIST_ACTIVE ?></th>
+					<th><?= L_CAT_LIST_SORT ?></th>
+					<th><?= L_CAT_LIST_BYPAGE ?></th>
+					<th data-id="order"><?= L_CAT_LIST_ORDER ?></th>
+					<th><?= L_CAT_LIST_MENU ?></th>
 					<th>&nbsp;</th>
 				</tr>
 			</thead>
@@ -78,7 +78,7 @@ include 'top.php';
 					echo '<tr>';
 					echo '<td><input type="checkbox" name="idCategory[]" value="'.$k.'" /><input type="hidden" name="catNum[]" value="'.$k.'" /></td>';
 					echo '<td>'.$k.'</td><td>';
-					plxUtils::printInput($k.'_name', plxUtils::strCheck($v['name']), 'text', '-50');
+					plxUtils::printInput($k.'_name', plxUtils::strCheck($v['name']), 'text', '-50', false, '', '', '', true);
 					echo '</td><td>';
 					plxUtils::printInput($k.'_url', $v['url'], 'text', '-50');
 					echo '</td><td>';
@@ -105,7 +105,7 @@ include 'top.php';
 			$new_catid = str_pad($a['0']+1, 3, "0", STR_PAD_LEFT);
 			?>
 				<tr class="new">
-					<td colspan="2"><?php echo L_NEW_CATEGORY ?></td>
+					<td colspan="2"><?= L_NEW_CATEGORY ?></td>
 					<td>
 					<?php
 						echo '<input type="hidden" name="catNum[]" value="'.$new_catid.'" />';

--- a/core/admin/comment.php
+++ b/core/admin/comment.php
@@ -123,33 +123,33 @@ if($plxAdmin->plxRecord_coms->f('type') != 'admin') {
 
 ?>
 
-<form action="comment.php<?php echo (!empty($_GET['a'])?'?a='.plxUtils::strCheck($_GET['a']):'') ?>" method="post" id="form_comment">
+<form action="comment.php<?= (!empty($_GET['a'])?'?a='.plxUtils::strCheck($_GET['a']):'') ?>" method="post" id="form_comment">
 
 	<div class="inline-form action-bar">
-		<h2><?php echo L_COMMENT_EDITING ?></h2>
+		<h2><?= L_COMMENT_EDITING ?></h2>
 		<?php if(!empty($_GET['a'])) : ?>
-		<p><a class="back" href="comments.php?a=<?php echo $_GET['a'] ?>"><?php echo L_BACK_TO_ARTICLE_COMMENTS ?></a></p>
+		<p><a class="back" href="comments.php?a=<?= $_GET['a'] ?>"><?= L_BACK_TO_ARTICLE_COMMENTS ?></a></p>
 		<?php else : ?>
-		<p><a class="back" href="comments.php"><?php echo L_BACK_TO_COMMENTS ?></a></p>
+		<p><a class="back" href="comments.php"><?= L_BACK_TO_COMMENTS ?></a></p>
 		<?php endif; ?>
 		<?php if($com['comStatus']=='') : ?>
-		<input type="submit" name="offline" value="<?php echo L_COMMENT_OFFLINE_BUTTON ?>" />
-		<input type="submit" name="answer" value="<?php echo L_COMMENT_ANSWER_BUTTON ?>" />
+		<input type="submit" name="offline" value="<?= L_COMMENT_OFFLINE_BUTTON ?>" />
+		<input type="submit" name="answer" value="<?= L_COMMENT_ANSWER_BUTTON ?>" />
 		<?php else : ?>
-		<input type="submit" name="online" value="<?php echo L_COMMENT_PUBLISH_BUTTON ?>" />
+		<input type="submit" name="online" value="<?= L_COMMENT_PUBLISH_BUTTON ?>" />
 		<?php endif; ?>
-		<input type="submit" name="update" value="<?php echo L_COMMENT_UPDATE_BUTTON ?>" />
-		<span class="sml-hide med-show">&nbsp;&nbsp;&nbsp;</span><input class="red" type="submit" name="delete" value="<?php echo L_DELETE ?>" onclick="Check=confirm('<?php echo L_COMMENT_DELETE_CONFIRM ?>');if(Check==false) return false;"/>
-		<?php echo plxToken::getTokenPostMethod() ?>
+		<input type="submit" name="update" value="<?= L_COMMENT_UPDATE_BUTTON ?>" />
+		<span class="sml-hide med-show">&nbsp;&nbsp;&nbsp;</span><input class="red" type="submit" name="delete" value="<?= L_DELETE ?>" onclick="Check=confirm('<?= L_COMMENT_DELETE_CONFIRM ?>');if(Check==false) return false;"/>
+		<?= plxToken::getTokenPostMethod() ?>
 	</div>
 
 	<?php eval($plxAdmin->plxPlugins->callHook('AdminCommentTop')) # Hook Plugins ?>
 
 	<ul class="unstyled-list">
-		<li><?php echo L_COMMENT_IP_FIELD ?> : <?php echo $plxAdmin->plxRecord_coms->f('ip'); ?></li>
-		<li><?php echo L_COMMENT_STATUS_FIELD ?> : <?php echo $statut; ?></li>
-		<li><?php echo L_COMMENT_TYPE_FIELD ?> : <strong><?php echo $plxAdmin->plxRecord_coms->f('type'); ?></strong></li>
-		<li><?php echo L_COMMENT_LINKED_ARTICLE_FIELD ?> : <?php echo $article; ?></li>
+		<li><?= L_COMMENT_IP_FIELD ?> : <?= $plxAdmin->plxRecord_coms->f('ip'); ?></li>
+		<li><?= L_COMMENT_STATUS_FIELD ?> : <?= $statut; ?></li>
+		<li><?= L_COMMENT_TYPE_FIELD ?> : <strong><?= $plxAdmin->plxRecord_coms->f('type'); ?></strong></li>
+		<li><?= L_COMMENT_LINKED_ARTICLE_FIELD ?> : <?= $article; ?></li>
 	</ul>
 
 	<fieldset>
@@ -157,18 +157,18 @@ if($plxAdmin->plxRecord_coms->f('type') != 'admin') {
 
 		<div class="grid inline-form publication">
 			<div class="col sml-12">
-				<label><?php echo L_COMMENT_DATE_FIELD ?>&nbsp;:</label>
+				<label><?= L_COMMENT_DATE_FIELD ?>&nbsp;:</label>
 				<?php plxUtils::printInput('date_publication_day',$date['day'],'text','2-2',false,'day'); ?>
 				<?php plxUtils::printInput('date_publication_month',$date['month'],'text','2-2',false,'month'); ?>
 				<?php plxUtils::printInput('date_publication_year',$date['year'],'text','2-4',false,'year'); ?>
 				<?php plxUtils::printInput('date_publication_time',$date['time'],'text','2-5',false,'time'); ?>
-				<a href="javascript:void(0)" onclick="dateNow('date_publication', <?php echo date('Z') ?>); return false;" title="<?php L_NOW; ?>"><img src="theme/images/date.png" alt="" /></a>
+				<a href="javascript:void(0)" onclick="dateNow('date_publication', <?= date('Z') ?>); return false;" title="<?php L_NOW; ?>"><img src="theme/images/date.png" alt="" /></a>
 			</div>
 		</div>
 
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_author"><?php echo L_COMMENT_AUTHOR_FIELD ?> :</label>
+				<label for="id_author"><?= L_COMMENT_AUTHOR_FIELD ?> :</label>
 				<?php plxUtils::printInput('author',$author,'text','40-255') ?>
 			</div>
 		</div>
@@ -176,7 +176,7 @@ if($plxAdmin->plxRecord_coms->f('type') != 'admin') {
 		<div class="grid">
 			<div class="col sml-12">
 				<label for="id_site">
-				<?php echo L_COMMENT_SITE_FIELD.'&nbsp;:&nbsp;';
+				<?= L_COMMENT_SITE_FIELD.'&nbsp;:&nbsp;';
 				if($site != '')	echo '<a href="'.$site.'">'.$site.'</a>';
 				?>
 				</label>
@@ -188,9 +188,9 @@ if($plxAdmin->plxRecord_coms->f('type') != 'admin') {
 
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_mail"><?php echo L_COMMENT_EMAIL_FIELD ?> :
+				<label for="id_mail"><?= L_COMMENT_EMAIL_FIELD ?> :
 				<?php if($plxAdmin->plxRecord_coms->f('mail') != '') : ?>
-				<?php echo '<a href="mailto:'.$plxAdmin->plxRecord_coms->f('mail').'">'.$plxAdmin->plxRecord_coms->f('mail').'</a>' ?>
+				<a href="mailto:<?= $plxAdmin->plxRecord_coms->f('mail') ?>"><?= $plxAdmin->plxRecord_coms->f('mail') ?></a>
 				<?php endif; ?>
 				</label>
 				<?php plxUtils::printInput('mail',plxUtils::strCheck($plxAdmin->plxRecord_coms->f('mail')),'text','40-255') ?>
@@ -199,8 +199,8 @@ if($plxAdmin->plxRecord_coms->f('type') != 'admin') {
 
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_content"><?php echo L_COMMENT_ARTICLE_FIELD ?> :</label>
-				<?php plxUtils::printArea('content',$content, 0, 7); ?>
+				<label for="id_content"><?= L_COMMENT_ARTICLE_FIELD ?> :</label>
+				<?php plxUtils::printArea('content',$content,0,7,false,'full-width','placeholder=" "'); ?>
 				<?php eval($plxAdmin->plxPlugins->callHook('AdminComment')) # Hook Plugins ?>
 			</div>
 		</div>

--- a/core/admin/comment_new.php
+++ b/core/admin/comment_new.php
@@ -132,25 +132,25 @@ if(!empty($_POST) AND !empty($_POST['content'])) {
 # On inclut le header
 include 'top.php';
 ?>
-<form action="comment_new.php?<?php echo plxUtils::strCheck($get) ?>" method="post" id="form_comment">
+<form action="comment_new.php?<?= plxUtils::strCheck($get) ?>" method="post" id="form_comment">
 
 	<div class="inline-form action-bar">
-		<h2><?php echo L_CREATE_NEW_COMMENT ?></h2>
+		<h2><?= L_CREATE_NEW_COMMENT ?></h2>
 		<?php if(!empty($_GET['a'])) : ?>
-		<p><a class="back" href="comments.php?a=<?php echo $_GET['a']; ?>"><?php echo L_BACK_TO_ARTICLE_COMMENTS ?></a></p>
+		<p><a class="back" href="comments.php?a=<?= $_GET['a']; ?>"><?= L_BACK_TO_ARTICLE_COMMENTS ?></a></p>
 		<?php else : ?>
-		<p><a class="back" href="comments.php"><?php echo L_BACK_TO_COMMENTS ?></a></p>
+		<p><a class="back" href="comments.php"><?= L_BACK_TO_COMMENTS ?></a></p>
 		<?php endif; ?>
-		<input type="submit" name="create" value="<?php echo L_COMMENT_SAVE_BUTTON ?>"/>
+		<input type="submit" name="create" value="<?= L_COMMENT_SAVE_BUTTON ?>"/>
 	</div>
 
 	<?php eval($plxAdmin->plxPlugins->callHook('AdminCommentNewTop')) # Hook Plugins ?>
 
-	<h3 class="no-margin"><?php echo L_COMMENT_LINKED_ARTICLE_FIELD ?>&nbsp;:&nbsp;<?php echo $article ?></h3>
+	<h3 class="no-margin"><?= L_COMMENT_LINKED_ARTICLE_FIELD ?>&nbsp;:&nbsp;<?= $article ?></h3>
 
 	<ul class="unstyled-list">
-		<li><?php echo L_COMMENT_AUTHOR_FIELD ?> : <strong><?php echo plxUtils::strCheck($plxAdmin->aUsers[$_SESSION['user']]['name']); ?></strong></li>
-		<li><?php echo L_COMMENT_TYPE_FIELD ?> : <strong>admin</strong></li>
+		<li><?= L_COMMENT_AUTHOR_FIELD ?> : <strong><?= plxUtils::strCheck($plxAdmin->aUsers[$_SESSION['user']]['name']); ?></strong></li>
+		<li><?= L_COMMENT_TYPE_FIELD ?> : <strong>admin</strong></li>
 	</ul>
 
 	<fieldset>
@@ -158,9 +158,9 @@ include 'top.php';
 			<div class="col sml-12">
 				<div id="id_answer"></div>
 				<?php plxUtils::printInput('parent',$parent,'hidden'); ?>
-				<?php echo plxToken::getTokenPostMethod() ?>
-				<label for="id_content"><?php echo L_COMMENT_ARTICLE_FIELD ?>&nbsp;:</label>
-				<?php plxUtils::printArea('content',plxUtils::strCheck($content), 60, 7, false,'full-width'); ?>
+				<?= plxToken::getTokenPostMethod() ?>
+				<label for="id_content"><?= L_COMMENT_ARTICLE_FIELD ?>&nbsp;:</label>
+				<?php plxUtils::printArea('content',plxUtils::strCheck($content),60,7,false,'full-width','placeholder=" "'); ?>
 				<?php eval($plxAdmin->plxPlugins->callHook('AdminCommentNew')) # Hook Plugins ?>
 			</div>
 		</div>
@@ -168,19 +168,19 @@ include 'top.php';
 </form>
 
 <?php if(isset($plxAdmin->plxRecord_coms)) : # On a des commentaires ?>
-	<h3><?php echo L_ARTICLE_COMMENTS_LIST ?></h3>
+	<h3><?= L_ARTICLE_COMMENTS_LIST ?></h3>
 	<?php while($plxAdmin->plxRecord_coms->loop()) : # On boucle ?>
 		<?php $comId = $plxAdmin->plxRecord_coms->f('article').'.'.$plxAdmin->plxRecord_coms->f('numero'); ?>
-		<div id="c<?php echo $comId ?>" class="comment<?php echo ((isset($_GET['c']) AND $_GET['c']==$comId)?' current':'') ?> level-<?php echo $plxAdmin->plxRecord_coms->f('level'); ?>">
-			<div id="com-<?php echo $plxAdmin->plxRecord_coms->f('index'); ?>">
+		<div id="c<?= $comId ?>" class="comment<?= ((isset($_GET['c']) AND $_GET['c']==$comId)?' current':'') ?> level-<?= $plxAdmin->plxRecord_coms->f('level'); ?>">
+			<div id="com-<?= $plxAdmin->plxRecord_coms->f('index'); ?>">
 				<small>
-					<span class="nbcom">#<?php echo $plxAdmin->plxRecord_coms->i+1 ?></span>&nbsp;
-					<time datetime="<?php echo plxDate::formatDate($plxAdmin->plxRecord_coms->f('date'), '#num_year(4)-#num_month-#num_day #hour:#minute'); ?>"><?php echo plxDate::formatDate($plxAdmin->plxRecord_coms->f('date'), '#day #num_day #month #num_year(4) &agrave; #hour:#minute'); ?></time> -
-					<?php echo L_COMMENT_WRITTEN_BY ?>&nbsp;<strong><?php echo $plxAdmin->plxRecord_coms->f('author'); ?></strong>
-					- <a href="comment.php<?php echo (!empty($_GET['a']))?'?c='.$comId.'&amp;a='.$_GET['a']:'?c='.$comId; ?>" title="<?php echo L_COMMENT_EDIT_TITLE ?>"><?php echo L_COMMENT_EDIT ?></a>
-					- <a href="#form_comment" onclick="replyCom('<?php echo $plxAdmin->plxRecord_coms->f('index') ?>')"><?php echo L_COMMENT_ANSWER ?></a>
+					<span class="nbcom">#<?= $plxAdmin->plxRecord_coms->i+1 ?></span>&nbsp;
+					<time datetime="<?= plxDate::formatDate($plxAdmin->plxRecord_coms->f('date'), '#num_year(4)-#num_month-#num_day #hour:#minute'); ?>"><?= plxDate::formatDate($plxAdmin->plxRecord_coms->f('date'), '#day #num_day #month #num_year(4) &agrave; #hour:#minute'); ?></time> -
+					<?= L_COMMENT_WRITTEN_BY ?>&nbsp;<strong><?= $plxAdmin->plxRecord_coms->f('author'); ?></strong>
+					- <a href="comment.php<?= (!empty($_GET['a']))?'?c='.$comId.'&amp;a='.$_GET['a']:'?c='.$comId; ?>" title="<?= L_COMMENT_EDIT_TITLE ?>"><?= L_COMMENT_EDIT ?></a>
+					- <a href="#form_comment" onclick="replyCom('<?= $plxAdmin->plxRecord_coms->f('index') ?>')"><?= L_COMMENT_ANSWER ?></a>
 				</small>
-				<blockquote class="type-<?php echo $plxAdmin->plxRecord_coms->f('type'); ?>"><?php echo nl2br($plxAdmin->plxRecord_coms->f('content')); ?></blockquote>
+				<blockquote class="type-<?= $plxAdmin->plxRecord_coms->f('type'); ?>"><?= nl2br($plxAdmin->plxRecord_coms->f('content')); ?></blockquote>
 			</div>
 			<?php eval($plxAdmin->plxPlugins->callHook('AdminCommentNewList')) # Hook Plugins ?>
 		</div>
@@ -188,9 +188,9 @@ include 'top.php';
 <?php endif; ?>
 <script>
 function replyCom(idCom) {
-	document.getElementById('id_answer').innerHTML='<?php echo L_REPLY_TO ?> : ';
+	document.getElementById('id_answer').innerHTML='<?= L_REPLY_TO ?> : ';
 	document.getElementById('id_answer').innerHTML+=document.getElementById('com-'+idCom).innerHTML;
-	document.getElementById('id_answer').innerHTML+='<a href="javascript:void(0)" onclick="cancelCom()"><?php echo L_CANCEL ?></a>';
+	document.getElementById('id_answer').innerHTML+='<a href="javascript:void(0)" onclick="cancelCom()"><?= L_CANCEL ?></a>';
 	document.getElementById('id_answer').style.display='inline-block';
 	document.getElementById('id_parent').value=idCom;
 	document.getElementById('id_content').focus();

--- a/core/admin/js/visual.js
+++ b/core/admin/js/visual.js
@@ -100,8 +100,8 @@ var DragDrop = {
 (function() {
 	// Checks password
 
-	// Enable only for install.php and profil.php
-	if(!/\/(?:install|profil)\.php$/.test(document.URL)) {
+	// Disable for auth.php + ?p= but active on auth.php?.* (plugins & action=changepassword)
+	if(/((?:\/auth\.php)(?:\?p=)?)(?!\?.*=)/.test(document.URL)) {
 		return
 	}
 

--- a/core/admin/parametres_affichage.php
+++ b/core/admin/parametres_affichage.php
@@ -202,7 +202,7 @@ include 'top.php';
 		<div class="grid">
 			<div class="col sml-12">
 				<label for="id_content"><?= L_CONFIG_VIEW_FEEDS_FOOTER ?>&nbsp;:</label>
-				<?php plxUtils::printArea('content',plxUtils::strCheck($plxAdmin->aConf['feed_footer']),140,5,false,'full-width'); ?>
+				<?php plxUtils::printArea('content',plxUtils::strCheck($plxAdmin->aConf['feed_footer']),140,5,false,'full-width','placeholder=" "'); ?>
 			</div>
 		</div>
 

--- a/core/admin/parametres_edittpl.php
+++ b/core/admin/parametres_edittpl.php
@@ -75,22 +75,22 @@ include 'top.php';
 <form action="parametres_edittpl.php" method="post" id="form_edittpl">
 
 	<div class="inline-form action-bar">
-		<h2><?php echo L_CONFIG_EDITTPL_TITLE ?> &laquo;<?php echo plxUtils::strCheck($style) ?>&raquo;</h2>
-		<p><?php echo L_CONFIG_VIEW_PLUXML_RESSOURCES ?></p>
-		<?php echo plxToken::getTokenPostMethod() ?>
+		<h2><?= L_CONFIG_EDITTPL_TITLE ?> &laquo;<?= plxUtils::strCheck($style) ?>&raquo;</h2>
+		<p><?= L_CONFIG_VIEW_PLUXML_RESSOURCES ?></p>
+		<?= plxToken::getTokenPostMethod() ?>
 		<?php plxUtils::printSelectDir('template', $tpl, PLX_ROOT.$plxAdmin->aConf['racine_themes'].$style, 'no-margin', false) ?>
-		<input name="load" type="submit" value="<?php echo L_CONFIG_EDITTPL_LOAD ?>" />
+		<input name="load" type="submit" value="<?= L_CONFIG_EDITTPL_LOAD ?>" />
 		<span class="sml-hide med-show">&nbsp;&nbsp;&nbsp;</span>
-		<input name="submit" type="submit" value="<?php echo L_SAVE_FILE ?>" />
+		<input name="submit" type="submit" value="<?= L_SAVE_FILE ?>" />
 	</div>
 
 	<?php eval($plxAdmin->plxPlugins->callHook('AdminSettingsEdittplTop')) # Hook Plugins ?>
 
 	<div class="grid">
 		<div class="col sml-12">
-			<label for="id_content"><?php echo L_CONTENT_FIELD ?>&nbsp;:</label>
+			<label for="id_content"><?= L_CONTENT_FIELD ?>&nbsp;:</label>
 			<?php plxUtils::printInput('tpl',plxUtils::strCheck($tpl),'hidden'); ?>
-			<?php plxUtils::printArea('content',plxUtils::strCheck($content), 0, 20); ?>
+			<?php plxUtils::printArea('content',plxUtils::strCheck($content),0,20,false,'full-width','placeholder=" "'); ?>
 			<?php eval($plxAdmin->plxPlugins->callHook('AdminSettingsEdittpl')) # Hook Plugins ?>
 		</div>
 	</div>

--- a/core/admin/parametres_plugincss.php
+++ b/core/admin/parametres_plugincss.php
@@ -50,26 +50,26 @@ include 'top.php';
 
 ?>
 
-<form action="parametres_plugincss.php?p=<?php echo urlencode($plugin) ?>" method="post" id="form_file">
+<form action="parametres_plugincss.php?p=<?= urlencode($plugin) ?>" method="post" id="form_file">
 	<div class="inline-form action-bar">
-		<h2><?php echo plxUtils::strCheck($plugin) ?></h2>
-		<?php echo '<p><a class="back" href="parametres_plugins.php">'.L_BACK_TO_PLUGINS.'</a></p>'; ?>
-		<input name="submit" type="submit" value="<?php echo L_SAVE_FILE ?>" />
+		<h2><?= plxUtils::strCheck($plugin) ?></h2>
+		<p><a class="back" href="parametres_plugins.php"><?= L_BACK_TO_PLUGINS ?></a></p>
+		<input name="submit" type="submit" value="<?= L_SAVE_FILE ?>" />
 	</div>
 
 	<fieldset>
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_frontend"><?php echo L_CONTENT_FIELD_FRONTEND ?>&nbsp;:</label>
-				<?php plxUtils::printArea('frontend',plxUtils::strCheck($frontend), 0, 20); ?>
+				<label for="id_frontend"><?= L_CONTENT_FIELD_FRONTEND ?>&nbsp;:</label>
+				<?php plxUtils::printArea('frontend',plxUtils::strCheck($frontend),0,20,false,'full-width','placeholder=" "'); ?>
 			</div>
 		</div>
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_backend"><?php echo L_CONTENT_FIELD_BACKEND ?>&nbsp;:</label>
-				<?php plxUtils::printArea('backend',plxUtils::strCheck($backend), 0, 20); ?>
+				<label for="id_backend"><?= L_CONTENT_FIELD_BACKEND ?>&nbsp;:</label>
+				<?php plxUtils::printArea('backend',plxUtils::strCheck($backend),0,20,false,'full-width','placeholder=" "'); ?>
 				<?php eval($plxAdmin->plxPlugins->callHook('AdminPluginCss')) # Hook Plugins ?>
-				<?php echo plxToken::getTokenPostMethod() ?>
+				<?= plxToken::getTokenPostMethod() ?>
 			</div>
 		</div>
 	</fieldset>

--- a/core/admin/parametres_users.php
+++ b/core/admin/parametres_users.php
@@ -23,18 +23,20 @@ if (!empty($_POST)) {
 
 # On inclut le header
 include 'top.php';
+
+$requireMail = boolval($plxAdmin->aConf['lostpassword']);
 ?>
 
 <form action="parametres_users.php" method="post" id="form_users">
 
 	<div class="inline-form action-bar">
-		<h2><?php echo L_CONFIG_USERS_TITLE; ?></h2>
+		<h2><?= L_CONFIG_USERS_TITLE; ?></h2>
 		<p>&nbsp;</p>
 		<?php plxUtils::printSelect('selection', array( '' => L_FOR_SELECTION, 'delete' => L_DELETE), '', false, 'no-margin', 'id_selection') ?>
-		<input type="submit" name="submit" value="<?php echo L_OK ?>" onclick="return confirmAction(this.form, 'id_selection', 'delete', 'idUser[]', '<?php echo L_CONFIRM_DELETE ?>')" />
-		<?php echo plxToken::getTokenPostMethod() ?>
+		<input type="submit" name="submit" value="<?= L_OK ?>" onclick="return confirmAction(this.form, 'id_selection', 'delete', 'idUser[]', '<?= L_CONFIRM_DELETE ?>')" />
+		<?= plxToken::getTokenPostMethod() ?>
 		<span class="sml-hide med-show">&nbsp;&nbsp;&nbsp;</span>
-		<input type="submit" name="update" value="<?php echo L_CONFIG_USERS_UPDATE ?>" />
+		<input type="submit" name="update" value="<?= L_CONFIG_USERS_UPDATE ?>" />
 	</div>
 
 	<?php eval($plxAdmin->plxPlugins->callHook('AdminUsersTop')) # Hook Plugins ?>
@@ -44,14 +46,14 @@ include 'top.php';
 	<thead>
 		<tr>
 			<th class="checkbox"><input type="checkbox" onclick="checkAll(this.form, 'idUser[]')" /></th>
-			<th><?php echo L_ID ?></th>
-			<th><?php echo L_PROFIL_USER ?></th>
-			<th><?php echo L_PROFIL_LOGIN ?></th>
-			<th><?php echo L_PROFIL_PASSWORD ?></th>
-			<th><?php echo L_PROFIL_MAIL ?></th>
-			<th><?php echo L_PROFIL ?></th>
-			<th><?php echo L_CONFIG_USERS_ACTIVE ?></th>
-			<th><?php echo L_CONFIG_USERS_ACTION ?></th>
+			<th><?= L_ID ?></th>
+			<th class="required"><?= L_PROFIL_USER ?></th>
+			<th class="required"><?= L_PROFIL_LOGIN ?></th>
+			<th><?= L_PROFIL_PASSWORD ?></th>
+			<th<?= ($requireMail? ' class="required"': '') ?>><?= L_PROFIL_MAIL ?></th>
+			<th><?= L_PROFIL ?></th>
+			<th><?= L_CONFIG_USERS_ACTIVE ?></th>
+			<th><?= L_CONFIG_USERS_ACTION ?></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -59,7 +61,7 @@ include 'top.php';
 	# Initialisation de l'ordre
 	$num = 0;
 	if($plxAdmin->aUsers) {
-		foreach($plxAdmin->aUsers as $_userid => $_user)	{
+		foreach($plxAdmin->aUsers as $_userid => $_user) {
 			if (!$_user['delete']) {
 ?>
 		<tr>
@@ -68,10 +70,10 @@ include 'top.php';
 				<input type="hidden" name="userNum[]" value="<?= $_userid ?>" />
 			</td>
 			<td><?= $_userid ?></td>
-			<td><?php plxUtils::printInput($_userid.'_name', plxUtils::strCheck($_user['name']), 'text', ''); ?></td>
-			<td><?php plxUtils::printInput($_userid.'_login', plxUtils::strCheck($_user['login']), 'text', ''); ?></td>
-			<td><?php plxUtils::printInput($_userid.'_password', '', 'password', '', false, '', '', 'onkeyup="pwdStrength(this.id)"'); ?></td>
-			<td><?php plxUtils::printInput($_userid.'_email', plxUtils::strCheck($_user['email']), 'email', ''); ?></td>
+			<td><?php plxUtils::printInput($_userid.'_name', plxUtils::strCheck($_user['name']), 'text', '', false, '', '', '', true); ?></td>
+			<td><?php plxUtils::printInput($_userid.'_login', plxUtils::strCheck($_user['login']), 'text', '', false, '', '', '', true); ?></td>
+			<td><?php plxUtils::printInput($_userid.'_password', '', 'password', ''); ?></td>
+			<td><?php plxUtils::printInput($_userid.'_email', plxUtils::strCheck($_user['email']), 'email', '', false, '', '', '', $requireMail); ?></td>
 			<td>
 <?php
 				if($_userid=='001') {
@@ -107,7 +109,7 @@ include 'top.php';
 	$new_userid = str_pad($a['0']+1, 3, "0", STR_PAD_LEFT);
 ?>
 		<tr class="new">
-			<td colspan="2"><?php echo L_CONFIG_USERS_NEW; ?></td>
+			<td colspan="2"><?= L_CONFIG_USERS_NEW ?></td>
 			<td>
 				<input type="hidden" name="userNum[]" value="<?= $new_userid ?>" />
 				<?php plxUtils::printInput($new_userid.'_newuser', 'true', 'hidden'); ?>
@@ -115,7 +117,7 @@ include 'top.php';
 				<?php plxUtils::printInput($new_userid.'_infos', '', 'hidden'); ?>
 			</td>
 			<td><?php plxUtils::printInput($new_userid.'_login', '', 'text', ''); ?></td>
-			<td><?php plxUtils::printInput($new_userid.'_password', '', 'password', '', false, '', '', 'onkeyup="pwdStrength(this.id)"'); ?></td>
+			<td><?php plxUtils::printInput($new_userid.'_password', '', 'password', ''); ?></td>
 			<td><?php plxUtils::printInput($new_userid.'_email', '', 'email', ''); ?></td>
 			<td><?php plxUtils::printSelect($new_userid.'_profil', PROFIL_NAMES, PROFIL_WRITER); ?></td>
 			<td><?php plxUtils::printSelect($new_userid.'_active', array('1'=>L_YES,'0'=>L_NO), '1'); ?></td>

--- a/core/admin/profil.php
+++ b/core/admin/profil.php
@@ -32,14 +32,15 @@ if(!empty($_POST)) {
 include 'top.php';
 
 $_profil = $plxAdmin->aUsers[$_SESSION['user']];
+$requireMail = boolval($plxAdmin->aConf['lostpassword']);
 ?>
 
 <form action="profil.php" method="post" id="form_profil">
 
 	<div class="inline-form action-bar">
-		<h2><?php echo L_PROFIL_EDIT_TITLE ?></h2>
-		<p><label><?php echo L_PROFIL_LOGIN ?>&nbsp;:&nbsp;<strong><?php echo plxUtils::strCheck($_profil['login']) ?></strong></label></p>
-		<input type="submit" name="profil" value="<?php echo L_PROFIL_UPDATE ?>" />
+		<h2><?= L_PROFIL_EDIT_TITLE ?></h2>
+		<p><label><?= L_PROFIL_LOGIN ?>&nbsp;:&nbsp;<strong><?= plxUtils::strCheck($_profil['login']) ?></strong></label></p>
+		<input type="submit" name="profil" value="<?= L_PROFIL_UPDATE ?>" />
 	</div>
 
 	<?php eval($plxAdmin->plxPlugins->callHook('AdminProfilTop')) # Hook Plugins ?>
@@ -47,54 +48,56 @@ $_profil = $plxAdmin->aUsers[$_SESSION['user']];
 	<fieldset>
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_name"><?php echo L_PROFIL_USER ?>&nbsp;:</label>
-				<?php plxUtils::printInput('name', plxUtils::strCheck($_profil['name']), 'text', '20-255') ?>
+				<label for="id_name" class="required"><?= L_PROFIL_USER ?>&nbsp;:</label>
+				<?php plxUtils::printInput('name', plxUtils::strCheck($_profil['name']), 'text', '20-255', false, '', '', '', true) ?>
 			</div>
 		</div>
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_email"><?php echo L_PROFIL_MAIL ?>&nbsp;:</label>
-				<?php plxUtils::printInput('email', plxUtils::strCheck($_profil['email']), 'text', '30-255') ?>
+				<label for="id_email"<?= ($requireMail? ' class="required"': '') ?>><?= L_PROFIL_MAIL ?>&nbsp;:</label>
+				<?php plxUtils::printInput('email', plxUtils::strCheck($_profil['email']), 'email', '', false, '', '', '', $requireMail) ?>
 			</div>
 		</div>
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_lang"><?php echo L_PROFIL_ADMIN_LANG ?>&nbsp;:</label>
+				<label for="id_lang"><?= L_PROFIL_ADMIN_LANG ?>&nbsp;:</label>
 				<?php plxUtils::printSelect('lang', plxUtils::getLangs(), $_profil['lang']) ?>
 			</div>
 		</div>
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_content"><?php echo L_PROFIL_INFOS ?>&nbsp;:</label>
-				<?php plxUtils::printArea('content',plxUtils::strCheck($_profil['infos']), 0, 5); ?>
+				<label for="id_content"><?= L_PROFIL_INFOS ?>&nbsp;:</label>
+				<?php plxUtils::printArea('content',plxUtils::strCheck($_profil['infos']), 0, 5, false ,'full-width', 'placeholder=" "'); ?>
 			</div>
 		</div>
 	</fieldset>
 	<?php eval($plxAdmin->plxPlugins->callHook('AdminProfil')) # Hook Plugins ?>
-	<?php echo plxToken::getTokenPostMethod() ?>
+	<?= plxToken::getTokenPostMethod() ?>
 
 </form>
 
-<h3><?php echo L_PROFIL_CHANGE_PASSWORD ?></h3>
+<h3><?= L_PROFIL_CHANGE_PASSWORD ?></h3>
 <form action="profil.php" method="post" id="form_password">
 	<fieldset>
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_password1"><?php echo L_PROFIL_PASSWORD ?>&nbsp;:</label>
+				<label for="id_password1" class="required"><?= L_PROFIL_PASSWORD ?>&nbsp;:</label>
+				<i class="ico icon-lock"></i>
 				<?php plxUtils::printInput('password1', '', 'password', '20-255', false, '', '', '', true) ?>
 			</div>
 		</div>
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_password2"><?php echo L_PROFIL_CONFIRM_PASSWORD ?>&nbsp;:</label>
+				<label for="id_password2" class="required"><?= L_PROFIL_CONFIRM_PASSWORD ?><span data-lang="&nbsp;❌|&nbsp;✅"></span>&nbsp;:</label>
+				<i class="ico icon-lock"></i>
 				<?php plxUtils::printInput('password2', '', 'password', '20-255', false, '', '', '', true) ?>
-				<span data-lang="❌|✅"></span>
+
 			</div>
 		</div>
 		<div class="grid">
 			<div class="col sml-12">
-				<?php echo plxToken::getTokenPostMethod() ?>
-				<input type="submit" name="password" value="<?php echo L_PROFIL_UPDATE_PASSWORD ?>" />
+				<?= plxToken::getTokenPostMethod() ?>
+				<input type="submit" name="password" value="<?= L_PROFIL_UPDATE_PASSWORD ?>" />
 			</div>
 		</div>
 	</fieldset>

--- a/core/admin/statique.php
+++ b/core/admin/statique.php
@@ -72,10 +72,10 @@ include 'top.php';
 <form action="statique.php" method="post" id="form_static">
 
 	<div class="inline-form action-bar">
-		<h2><?php echo L_STATIC_TITLE ?> "<?php echo plxUtils::strCheck($title); ?>"</h2>
-		<p><a class="back" href="statiques.php"><?php echo L_STATIC_BACK_TO_PAGE ?></a></p>
-		<input type="submit" value="<?php echo L_STATIC_UPDATE ?>"/>&nbsp;
-		<a href="<?php echo $url ?>" target="_blank"><?php echo L_STATIC_VIEW_PAGE ?> <?php echo plxUtils::strCheck($title); ?> <?php echo L_STATIC_ON_SITE ?></a>
+		<h2><?= L_STATIC_TITLE ?> "<?= plxUtils::strCheck($title); ?>"</h2>
+		<p><a class="back" href="statiques.php"><?= L_STATIC_BACK_TO_PAGE ?></a></p>
+		<input type="submit" value="<?= L_STATIC_UPDATE ?>"/>&nbsp;
+		<a href="<?= $url ?>" target="_blank"><?= L_STATIC_VIEW_PAGE ?> <?= plxUtils::strCheck($title); ?> <?= L_STATIC_ON_SITE ?></a>
 		<?php plxUtils::printInput('id', $id, 'hidden');?>
 	</div>
 
@@ -84,43 +84,43 @@ include 'top.php';
 		<fieldset>
 			<div class="grid">
 				<div class="col sml-12">
-					<label for="id_content"><?php echo L_CONTENT_FIELD ?>&nbsp;:</label>
-					<?php plxUtils::printArea('content', plxUtils::strCheck($content), 0, 30) ?>
+					<label for="id_content"><?= L_CONTENT_FIELD ?>&nbsp;:</label>
+					<?php plxUtils::printArea('content', plxUtils::strCheck($content), 0, 30, false, 'full-width', 'placeholder=" "') ?>
 				</div>
 			</div>
 			<div class="grid">
 				<div class="col sml-12">
-					<label for="id_template"><?php echo L_STATICS_TEMPLATE_FIELD ?>&nbsp;:</label>
+					<label for="id_template"><?= L_STATICS_TEMPLATE_FIELD ?>&nbsp;:</label>
 					<?php plxUtils::printSelect('template', $aTemplates, $template) ?>
 				</div>
 			</div>
 			<div class="grid">
 				<div class="col sml-12">
-					<label for="id_title_htmltag"><?php echo L_STATIC_TITLE_HTMLTAG ?>&nbsp;:</label>
+					<label for="id_title_htmltag"><?= L_STATIC_TITLE_HTMLTAG ?>&nbsp;:</label>
 					<?php plxUtils::printInput('title_htmltag',plxUtils::strCheck($title_htmltag),'text','50-255'); ?>
 				</div>
 			</div>
 			<div class="grid">
 				<div class="col sml-12">
-					<label for="id_meta_description"><?php echo L_STATIC_META_DESCRIPTION ?>&nbsp;:</label>
+					<label for="id_meta_description"><?= L_STATIC_META_DESCRIPTION ?>&nbsp;:</label>
 					<?php plxUtils::printInput('meta_description',plxUtils::strCheck($meta_description),'text','50-255'); ?>
 				</div>
 			</div>
 			<div class="grid">
 				<div class="col sml-12">
-					<label for="id_meta_keywords"><?php echo L_STATIC_META_KEYWORDS ?>&nbsp;:</label>
+					<label for="id_meta_keywords"><?= L_STATIC_META_KEYWORDS ?>&nbsp;:</label>
 					<?php plxUtils::printInput('meta_keywords',plxUtils::strCheck($meta_keywords),'text','50-255'); ?>
 				</div>
 			</div>
 			<div class="grid">
 				<div class="col sml-12">
-					<label><?php echo L_DATE_CREATION ?>&nbsp;:</label>
+					<label><?= L_DATE_CREATION ?>&nbsp;:</label>
 					<div class="inline-form creation">
 						<?php plxUtils::printInput('date_creation_day',$date_creation['day'],'text','2-2',false,'day'); ?>
 						<?php plxUtils::printInput('date_creation_month',$date_creation['month'],'text','2-2',false,'month'); ?>
 						<?php plxUtils::printInput('date_creation_year',$date_creation['year'],'text','2-4',false,'year'); ?>
 						<?php plxUtils::printInput('date_creation_time',$date_creation['time'],'text','2-5',false,'time'); ?>
-						<a class="ico_cal" href="javascript:void(0)" onclick="dateNow('date_creation', <?php echo date('Z') ?>); return false;" title="<?php L_NOW; ?>">
+						<a class="ico_cal" href="javascript:void(0)" onclick="dateNow('date_creation', <?= date('Z') ?>); return false;" title="<?php L_NOW; ?>">
 							<img src="theme/images/date.png" alt="calendar" />
 						</a>
 					</div>
@@ -129,13 +129,13 @@ include 'top.php';
 			<div class="grid">
 				<div class="col sml-12">
 					<?php plxUtils::printInput('date_update', $plxAdmin->aStats[$id]['date_update'], 'hidden');?>
-					<label><?php echo L_DATE_UPDATE ?>&nbsp;:</label>
+					<label><?= L_DATE_UPDATE ?>&nbsp;:</label>
 					<div class="inline-form update">
 						<?php plxUtils::printInput('date_update_day',$date_update['day'],'text','2-2',false,'day'); ?>
 						<?php plxUtils::printInput('date_update_month',$date_update['month'],'text','2-2',false,'month'); ?>
 						<?php plxUtils::printInput('date_update_year',$date_update['year'],'text','2-4',false,'year'); ?>
 						<?php plxUtils::printInput('date_update_time',$date_update['time'],'text','2-5',false,'time'); ?>
-						<a class="ico_cal" href="javascript:void(0)" onclick="dateNow('date_update', <?php echo date('Z') ?>); return false;" title="<?php L_NOW; ?>">
+						<a class="ico_cal" href="javascript:void(0)" onclick="dateNow('date_update', <?= date('Z') ?>); return false;" title="<?php L_NOW; ?>">
 							<img src="theme/images/date.png" alt="calendar" />
 						</a>
 					</div>
@@ -143,7 +143,7 @@ include 'top.php';
 			</div>
 		</fieldset>
 	<?php eval($plxAdmin->plxPlugins->callHook('AdminStatic')) # Hook Plugins ?>
-	<?php echo plxToken::getTokenPostMethod() ?>
+	<?= plxToken::getTokenPostMethod() ?>
 
 </form>
 

--- a/core/admin/theme/theme.css
+++ b/core/admin/theme/theme.css
@@ -448,7 +448,7 @@ input[maxlength="3"] {
 
 .publication input {
 	font-weight: bold;
-	color: #777;
+	color: #555;
 }
 
 .day,
@@ -472,12 +472,46 @@ input[maxlength="3"] {
 	color: #aaa;
 }
 
+.required::after {
+	content: '*';
+	color: red;
+	margin-left: 0.5rem;
+}
+
 input.readonly:focus {
 	border-color: #aaa;
 }
 
 input.readonly:hover {
 	cursor: not-allowed;
+}
+
+/* ---- validité dynamique ---- */
+
+input:invalid,
+textarea:invalid {
+	border: 1px solid #900000;
+}
+input:invalid:focus,
+textarea:invalid:focus {
+	border: 1px solid #c00000;
+}
+/* Bords vert si remplit et valide */
+input:not(:placeholder-shown):not([type="button"]):not([type="submit"]):not([type="reset"]):valid:focus,
+textarea:not(:placeholder-shown):valid:focus {
+	border: 1px solid #00c000;
+}
+/* Point rouge si invalide */
+input:not([type="radio"]):not([type="checkbox"]):optional:invalid:focus,
+input:not([type="radio"]):not([type="checkbox"]):required:invalid {
+	background-image: radial-gradient(
+			red 25%,
+			transparent 26%
+		),
+		radial-gradient(red 25%, transparent 26%);
+	background-size: 1.2em 1.2em;
+	background-position: right center;
+	background-repeat: no-repeat;
 }
 
 #id_link {

--- a/core/admin/user.php
+++ b/core/admin/user.php
@@ -38,15 +38,17 @@ elseif(!empty($_GET['p'])) { # On vérifie l'existence de l'utilisateur
 
 # On inclut le header
 include 'top.php';
+
+$requireMail = boolval($plxAdmin->aConf['lostpassword']);
 ?>
 
 <form action="user.php" method="post" id="form_user">
 
 	<div class="inline-form action-bar">
-		<h2><?php echo L_USER_PAGE_TITLE ?> "<?php echo plxUtils::strCheck($plxAdmin->aUsers[$id]['name']); ?>"</h2>
-		<p><a class="back" href="parametres_users.php"><?php echo L_USER_BACK_TO_PAGE ?></a></p>
-		<?php echo plxToken::getTokenPostMethod() ?>
-		<input type="submit" value="<?php echo L_USER_UPDATE ?>"/>
+		<h2><?= L_USER_PAGE_TITLE ?> "<?= plxUtils::strCheck($plxAdmin->aUsers[$id]['name']); ?>"</h2>
+		<p><a class="back" href="parametres_users.php"><?= L_USER_BACK_TO_PAGE ?></a></p>
+		<?= plxToken::getTokenPostMethod() ?>
+		<input type="submit" value="<?= L_USER_UPDATE ?>"/>
 	</div>
 
 	<?php eval($plxAdmin->plxPlugins->callHook('AdminUserTop')) # Hook Plugins ?>
@@ -55,7 +57,7 @@ include 'top.php';
 		<div class="grid">
 			<div class="col sml-12 med-5 label-centered">
 				<?php plxUtils::printInput('id', $id, 'hidden');?>
-				<label for="id_lang"><?php echo L_USER_LANG ?>&nbsp;:</label>
+				<label for="id_lang"><?= L_USER_LANG ?>&nbsp;:</label>
 			</div>
 			<div class="col sml-12 med-7">
 				<?php plxUtils::printSelect('lang', plxUtils::getLangs(), $plxAdmin->aUsers[$id]['lang']) ?>
@@ -63,16 +65,16 @@ include 'top.php';
 		</div>
 		<div class="grid">
 			<div class="col sml-12 med-5 label-centered">
-				<label for="id_email"><?php echo L_USER_MAIL ?>&nbsp;:</label>
+				<label for="id_email"<?= ($requireMail? ' class="required"': '') ?>><?= L_USER_MAIL ?>&nbsp;:</label>
 			</div>
 			<div class="col sml-12 med-7">
-				<?php plxUtils::printInput('email', plxUtils::strCheck($plxAdmin->aUsers[$id]['email']), 'email', '30-255') ?>
+				<?php plxUtils::printInput('email', plxUtils::strCheck($plxAdmin->aUsers[$id]['email']), 'email', '', false, '', '', '', $requireMail) ?>
 			</div>
 		</div>
 		<div class="grid">
 			<div class="col sml-12">
-				<label for="id_content"><?php echo L_USER_INFOS ?>&nbsp;:</label>
-				<?php plxUtils::printArea('content',plxUtils::strCheck($plxAdmin->aUsers[$id]['infos']), 0, 8) ?>
+				<label for="id_content"><?= L_USER_INFOS ?>&nbsp;:</label>
+				<?php plxUtils::printArea('content',plxUtils::strCheck($plxAdmin->aUsers[$id]['infos']),0,8,'full-width','placeholder=" "') ?>
 			</div>
 		</div>
 	</fieldset>

--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -257,14 +257,15 @@ class plxUtils {
 		 if(!empty($extra))
 			 $params[] = $extra;
 		 if($type != 'hidden') {
-			if($required === true)
-				$params[] = 'required="required"';
+			$className = explode(' ', trim($className));
 			if($readonly === true)
-				$params[] = 'readonly="readonly" class="readonly"';
-			if(!empty($className))
-				$params[] = 'class="'.$className.'"';
-			if(!empty($placeholder))
-				$params[] = 'placeholder="'.$placeholder.'"';
+				$params[] = $className[] = 'readonly';
+			elseif($required === true)
+				$params[] = $className[] = 'required';# Note : [L'attribut required n'est pas autorisé sur les entrées pour lesquelles l'attribut readonly est spécifié.](https://developer.mozilla.org/fr/docs/Web/HTML/Attributes/readonly#sect2)
+			if(!empty($className)) # fix double attribut 'class' class="readonly"
+				$params[] = 'class="'.$className = implode(' ', $className).'"';
+			if(in_array($type, explode(' ','text search url tel email password number')))
+				$params[] = 'placeholder="'.($placeholder?$placeholder:' ').'"';# Petit hack pour trouver les champs vide en css input:not(:placeholder-shown)
 			if(!empty($sizes) AND (strpos($sizes, '-') !== false)) {
 				list($size, $maxlength) = explode('-', $sizes);
 				if(!empty($size))
@@ -327,17 +328,14 @@ class plxUtils {
 				'name="' . $name . '"'
 		);
 		if (!empty($cols) and is_integer($cols)) {
-			$attrs [] = 'cols="' . $cols . '"';
+			$attrs[] = 'cols="' . $cols . '"';
 		}
 		if (!empty($rows) and is_integer($rows)) {
 			$attrs[] = 'rows="' . $rows . '"';
 		}
-		$classList = array();
+		$classList = explode(' ', trim($className));
 		if ($readonly === true) {
-			$classList[] = 'readonly';
-		}
-		if (!empty($className) and is_string($className) and strlen(trim($className)) > 0) {
-			$classList[] = trim($className);
+			$attrs[] = $classList[] = 'readonly';
 		}
 		if (!empty($classList)) {
 			$attrs[] = 'class="' . implode(' ', $classList) . '"';


### PR DESCRIPTION
Fix auth.php : &token= absent : Warn: Undefined array key "token"
••• $_GET['token'] filtré
Fix : pwdStrength() function undefined
••• auth.php + parametres_users - onkeyup="pwdStrength(this.id)"
••• visual.js [modif de regex](https://regexr.com/7r8kk) qui rend la fonction dispo partout
••• sauf sur auth.php : exeption de ?action=changepassword et plus
••• ••• Elle peut-être utile pour les plugins comme SignUp.
[+] <?php echo vers short open tag des fichiers changés
••• categorie, categories, comment, comment_news, statique
••• parametres_edittpl, parametres_pluincss
[+] Validité dynamique des champs de saisi et astérisques (theme.css)
[+] 'required' aux entrées obligatoires & '.required' a leurs label
••• Categories : Noms
••• Article : Titre et dates
••• Profil : Nom et Email*
••• Utilsateur : Nom et Email*
••• Gestion des utilisateurs : Nom, Login et Email*
••• * si lostPassword activé
[+] Aux Entrées et Aires de texte + placeholder=" "
••• Pour avoir le bord bleu d'origine (si champ vide)***
••• textarea avec $extra via les appels
••• input si $placeholder vide a l'appel il est ajouté par defaut***
[+] printArea remanié et readonly présent lorsque vrai
[+] printInput remanié
••• Fix class² si $readonly et $className
••• placeholder=" " avec un espace par defaut (si $placeholder='') 
••• ***Petit hack pour trouver les champs vide en css
••• ••• input:not(:placeholder-shown)
••• readonly ou required
> Note : [L'attribut required n'est pas autorisé sur les entrées pour
lesquelles l'attribut readonly est
spécifié.](https://developer.mozilla.org/fr/docs/Web/HTML/Attributes/readonly#sect2)

Inspired by
+ https://bobbyhadz.com/blog/mark-input-fields-as-required-using-asterisk
+ *** https://zellwk.com/blog/check-empty-input-css/
+ *** https://stackoverflow.com/a/52065435
and improved