### PR TITLE
plxFeed : getRss affichent avec l'entête et le pied du xml

### DIFF
--- a/core/lib/class.plx.record.php
+++ b/core/lib/class.plx.record.php
@@ -62,4 +62,26 @@ class plxRecord {
 			return false;
 	}
 
+	/**
+	 * Méthode pour retrouver la plus récente date
+	 *
+	 * @param	$field	nom du champ contenant la date
+	 * @return	Date la plus récente
+	 * @author	J.P. Pourrez
+	 *
+	 * Utilisé pour les flux RSS
+	 * */
+	public function lastUpdated($field='date') {
+		$last = '197001010100';
+		for($i=0; $i<$this->size; $i++) {
+			if(array_key_exists($field, $this->result[$i])) {
+				$value = $this->result[$i][$field];
+				if(preg_match('@^\d{12,}$@', $value) and $last < $value) {
+					$last = $value;
+				}
+			}
+		}
+		return $last;
+	}
+
 }


### PR DESCRIPTION
Jusqu'à la v5.8.9, ils faisaient comme ça.

- Conserve compatibilité descendante de certains plugins.

- Rend le hook plxFeedDemarrageEnd de nouveau utile.

- Utilise moins le buffer de sortie et petit fix de regex.

- Un strCheck simple pour title et description. (pourquoi bridé)

- La fonction lastUpdated de plxRecord viens de @bazooka07

Et pour suivre l'idée générale
- Nouvelle fonction getRssXml et ses deux nouveaux hooks 
- - plxFeedGetRssXmlHead
- - plxFeedGetRssXmlFoot