### PR TITLE
plxUtils : refacto strCheck + nouvelle sanitizeHtml

### DIFF
--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -284,11 +284,11 @@ class plxAdmin extends plxMotor {
 					# <!CDATA[..]]> est inutile :  valeur numerique, champs uniquement avec caractères alphanumérique
 					$content = plxUtils::strCheck($v);
 				} elseif(in_array($k, array('description', 'feed_footer'))) {
-					# On tolère quelques balises par défaut : <i>, <em>, <a>, <sup>, <span>,
+					# <!CDATA[..]]> On tolère les balises HTML
 					$content = plxUtils::strCheck($v, true);
 				} else {
-					# Aucune balise HTML tolérée
-					$content = plxUtils::strCheck($v, true, null);
+					# <!CDATA[..]]> Aucune balise HTML tolérée
+					$content = plxUtils::strCheck($v, true, true);
 				}
 ?>
 	<parametre name="<?= $k ?>"><?= $content ?></parametre>
@@ -971,12 +971,12 @@ EOT;
 	<categorie number="<?= $cat_id ?>" active="<?= $cat['active'] ?>" homepage="<?= $cat['homepage'] ?>" tri="<?= $cat['tri'] ?>" bypage="<?= $cat['bypage'] ?>" menu="<?= $cat['menu'] ?>" url="<?= $cat['url'] ?>" template="<?= basename($cat['template']) ?>">
 		<name><?= $cat['name'] ?></name>
 		<description><?= plxUtils::strCheck($cat['description'], true) ?></description>
-		<meta_description><?= plxUtils::strCheck($cat['meta_description'], true, null) ?></meta_description>
-		<meta_keywords><?= plxUtils::strCheck($cat['meta_keywords'], true, null) ?></meta_keywords>
-		<title_htmltag><?= plxUtils::strCheck($cat['title_htmltag'], true, null) ?></title_htmltag>
-		<thumbnail><?= plxUtils::strCheck($cat['thumbnail'], true, null) ?></thumbnail>
-		<thumbnail_alt><?= plxUtils::strCheck($cat['thumbnail_alt'], true) ?></thumbnail_alt>
-		<thumbnail_title><?= plxUtils::strCheck($cat['thumbnail_title'], true) ?></thumbnail_title>
+		<meta_description><?= plxUtils::strCheck($cat['meta_description']) ?></meta_description>
+		<meta_keywords><?= plxUtils::strCheck($cat['meta_keywords']) ?></meta_keywords>
+		<title_htmltag><?= plxUtils::strCheck($cat['title_htmltag']) ?></title_htmltag>
+		<thumbnail><?= plxUtils::strCheck($cat['thumbnail'], false, true) ?></thumbnail>
+		<thumbnail_alt><?= plxUtils::strCheck($cat['thumbnail_alt']) ?></thumbnail_alt>
+		<thumbnail_title><?= plxUtils::strCheck($cat['thumbnail_title']) ?></thumbnail_title>
 <?php
 				# Hook plugins
 				eval($this->plxPlugins->callHook('plxAdminEditCategoriesXml'));
@@ -1112,7 +1112,7 @@ EOT;
 	<statique number="<?= $static_id ?>" active="<?= $static['active'] ?>" menu="<?= $static['menu'] ?>" url="<?= $static['url'] ?>" template="<?= basename($static['template']) ?>">
 		<group><?= plxUtils::strCheck($static['group']) ?></group>
 		<name><?= plxUtils::strCheck($static['name']) ?></name>
-		<meta_description><?= plxUtils::strCheck($static['meta_description'], true) ?></meta_description>
+		<meta_description><?= plxUtils::strCheck($static['meta_description']) ?></meta_description>
 		<meta_keywords><?= plxUtils::strCheck($static['meta_keywords']) ?></meta_keywords>
 		<title_htmltag><?= plxUtils::strCheck($static['title_htmltag']) ?></title_htmltag>
 		<date_creation><?= $static['date_creation'] ?></date_creation>
@@ -1291,15 +1291,15 @@ EOT;
 	<title><?= plxUtils::strCheck(trim($content['title']), true) ?></title>
 	<allow_com><?= intval($content['allow_com']) ?></allow_com>
 	<template><?= basename($content['template']) ?></template>
-	<chapo><![CDATA[<?= plxUtils::sanitizePhpTags(trim($content['chapo'])) ?>]]></chapo>
-	<content><![CDATA[<?= plxUtils::sanitizePhpTags(trim($content['content'])) ?>]]></content>
-	<tags><?= plxUtils::strCheck(trim($content['tags']), true) ?></tags>
-	<meta_description><?= plxUtils::strCheck(trim($meta_description)) ?></meta_description>
-	<meta_keywords><?= plxUtils::strCheck(trim($meta_keywords)) ?></meta_keywords>
-	<title_htmltag><?= plxUtils::strCheck(trim($title_htmltag)) ?></title_htmltag>
-	<thumbnail><?= plxUtils::strCheck(trim($thumbnail)) ?></thumbnail>
-	<thumbnail_alt><?= plxUtils::strCheck(trim($thumbnail_alt), true) ?></thumbnail_alt>
-	<thumbnail_title><?= plxUtils::strCheck(trim($thumbnail_title), true) ?></thumbnail_title>
+	<chapo><?= plxUtils::strCheck(trim($content['chapo']), true) ?></chapo>
+	<content><?= plxUtils::strCheck(trim($content['content']), true) ?></content>
+	<tags><?= plxUtils::strCheck(trim($content['tags']), false, true) ?></tags>
+	<meta_description><?= plxUtils::strCheck(trim($meta_description), false, true) ?></meta_description>
+	<meta_keywords><?= plxUtils::strCheck(trim($meta_keywords), false, true) ?></meta_keywords>
+	<title_htmltag><?= plxUtils::strCheck(trim($title_htmltag), false, true) ?></title_htmltag>
+	<thumbnail><?= plxUtils::strCheck(trim($thumbnail), false, true) ?></thumbnail>
+	<thumbnail_alt><?= plxUtils::strCheck(trim($thumbnail_alt)) ?></thumbnail_alt>
+	<thumbnail_title><?= plxUtils::strCheck(trim($thumbnail_title)) ?></thumbnail_title>
 	<date_creation><?= $dates['creation'] ?></date_creation>
 	<date_update><?= $dates['update'] ?></date_update>
 <?php

--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -1122,12 +1122,12 @@ class plxMotor {
 		ob_start();
 ?>
 <comment>
-	<author><![CDATA[<?= plxUtils::cdataCheck($content['author']) ?>]]></author>
+	<author><?= plxUtils::strCheck($content['author']) ?></author>
 	<type><?= $content['type'] ?></type>
 	<ip><?= $content['ip'] ?></ip>
 	<mail><?= plxUtils::strCheck($content['mail']) ?></mail>
 	<site><?= plxUtils::strCheck($content['site']) ?></site>
-	<content><?= plxUtils::strCheck($content['content'], true) ?></content>
+	<content><?= plxUtils::strCheck($content['content'], true, '<a><b><i><p><q><u><em><sub><sup><del><pre><code><span><strong>', true) ?></content>
 	<parent><?= !empty($content['parent']) ? intval($content['parent']) : '' ?></parent>
 <?php
 

--- a/themes/defaut/commentaires.php
+++ b/themes/defaut/commentaires.php
@@ -21,7 +21,7 @@ if($plxShow->plxMotor->plxRecord_coms) {
 					<?php $plxShow->lang('SAID'); ?> :
 				</small>
 				<blockquote>
-					<p class="content_com type-<?php $plxShow->comType(); ?>"><?php $plxShow->comContent(); ?></p>
+					<div class="content_com type-<?php $plxShow->comType(); ?>"><?php $plxShow->comContent(); ?></div>
 				</blockquote>
 			</div>
 <?php


### PR DESCRIPTION
Nouvelle logique pour $tags : `true` == interdit ou liste des admis Les guillemts `"` sont convertis et de nouveau authorisées ds CDATA L'option CDATA est protègé par plxUtils::cdataCheck Previent les attaques XSS JS possible avec le dernier param à `true`

Corrige :
<a href="#" style="font-size:60px" data-code="[[code]]">lien</a> Donnais (description de catégorie, Flux RSS, etc...) <a href=# style=font-size:60px data-code=[[code]]>tien</a>

plxMotor->addCommentaire
On autorise les balises HTML :
<a><b><i><p><q><u><em><sub><sup><del><pre><code><span><strong> Où l'on supprime tous les scripts
et ne garde que les attributs src, class et href sans javascript. On supprime aussi style car imaginons un petit malin faire : <p style=font-size:10000px ... sur un commentaire ;)

plxAdmin (Re-)permet de :
Les metas, alts et titles sont convertis mieux qu'à l'origine. Par exemple, utile pour un article de tuto sur les balises ;) Pourquoi s'en privé :)

Note : sanitizeHtml ajoute un <p> pour les textes sans balise, d'où le remplacement de p par div ds theme/defaut/commentaires

Idée : un éditeur HTML leger pour les commentaires.