### PR TITLE
Fix webp animée et doc affiche icon.png : thumb & zoombox

### DIFF
--- a/core/admin/medias.php
+++ b/core/admin/medias.php
@@ -245,7 +245,7 @@ if($plxMedias->aFiles) {
 		}
 		ob_start();
 ?>
-							<img alt="<?= $title ?>" src="<?= $v['.thumb'] ?>" class="thumb" <?= $dimThumb[3] ?> />
+							<img alt="<?= $title ?>" src="<?= $v['.thumb'] ?>" class="<?=$isImage?'thumb':'file'?>" <?= $dimThumb[3] ?> />
 <?php
 		$thumbImg = ob_get_clean();
 		if($isImage AND is_file($v['path'])) {

--- a/core/lib/class.plx.medias.php
+++ b/core/lib/class.plx.medias.php
@@ -97,7 +97,7 @@ class plxMedias {
 	 *
 	 * @param	dir		répertoire de lecture
 	 * @return	array	tableau contenant la liste de tous les fichiers d'un dossier
-	 * @author	Stephane F
+	 * @author	Stephane F, JP Pourrez "bazooka07", T Ingles "sudwebdesign"
 	 **/
 	private function _getDirFiles($dir) {
 
@@ -131,10 +131,14 @@ class plxMedias {
 						file_exists($iconName) or
 						plxUtils::makeThumb(
 							$filename,
-							$iconName,
-							)
+							$iconName
+						)
 					) {
 						$sample = $iconName;
+					}
+					# webp animée et icône non crée par php
+					if($extension == '.webp' and !file_exists($iconName)) {
+						$sample = $filename;
 					}
 					$imgSize = getimagesize($filename);
 				} else {

--- a/core/lib/class.plx.medias.php
+++ b/core/lib/class.plx.medias.php
@@ -131,7 +131,7 @@ class plxMedias {
 						file_exists($iconName) or
 						plxUtils::makeThumb(
 							$filename,
-							$iconName
+							$iconName,
 						)
 					) {
 						$sample = $iconName;


### PR DESCRIPTION
L'icône des documents affichait l'icône lors du clic.
Cause : la classe .thumb de l'image (maintenant .file)

De même si une image webp est animée (maintenant ok)
L'icône de la miniature est l'image originale (à la svg)

Remplace PR #720
Fix Animated webp show icon.png in thumb & zoombox : admin medias