### PR TITLE
plxUtil::unSlash : Recursivité sur les tableaux

### DIFF
--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -100,7 +100,7 @@ class plxUtils {
 				if(is_array($v)) {
 					$new_content[$k] = array();
 					foreach($v as $key=>$val)
-						$new_content[$k][$key] = stripslashes($val);
+						$new_content[$k][$key] = self::unSlash($val);
 				} else {
 					$new_content[$k] = stripslashes($v);
 				}


### PR DESCRIPTION
Si un élément du tableau passé en paramètre à plxUtils::unslash() est un tableau, on rappelle cette fonction de façon récursive.