### PR TITLE
Fix icônes copier, renommer au dessus de l'entête du tableau medias lors du défilement

### DIFF
--- a/core/admin/theme/theme.css
+++ b/core/admin/theme/theme.css
@@ -937,7 +937,7 @@ div.ico {
 	color: #ccc;
 	display: inline-block;
 	margin-left: 5px;
-	position: relative;
+	position: initial;
 }
 
 div.ico:hover {


### PR DESCRIPTION
![medias_icones-copier-url-renomme_au-dessus-en-tete-table](https://github.com/pluxml/PluXml/assets/1390644/aecf40cf-7604-426d-9460-99b34ba9019f)
