### PR TITLE
Admin : Longues lignes des tableaux défilent et ont des élipses

### DIFF
--- a/core/admin/comments.php
+++ b/core/admin/comments.php
@@ -157,13 +157,41 @@ if(!empty($_GET['a'])) {
 		<?= plxToken::getTokenPostMethod() ?>
 		<input type="submit" name="btn_ok" value="<?= L_OK ?>" onclick="return confirmAction(this.form, 'id_selection', 'delete', 'idCom[]', '<?= L_CONFIRM_DELETE ?>')" />
 	</div>
+	<div class="grid">
+		<div class="col sml-12">
 <?php
 if(!empty($portee)) {
 ?>
-	<h3><a href="article.php?a=<?= $_GET['a'] ?>" title="<?= L_COMMENT_ARTICLE_LINKED_TITLE ?>"><?= $portee ?></a></h3>
+			<h3><a href="article.php?a=<?= $_GET['a'] ?>" title="<?= L_COMMENT_ARTICLE_LINKED_TITLE ?>"><?= $portee ?></a></h3>
+<?php
+}
+
+if(!empty($plxAdmin->aConf['clef'])) {
+?>
+			<input class="toggler" type="checkbox" id="toggler_rss" />
+			<label class="float-left" for="toggler_rss"><?= L_COMMENTS_PRIVATE_FEEDS ?> : <span class="icon-angle-left"></span><span class="icon-angle-right"></span></label>
+			<span class="float-left">
+				<ul class="menu">
+<?php
+				$options = array(
+					'hors-ligne'	=> L_COMMENT_OFFLINE_FEEDS,
+					'en-ligne'		=> L_COMMENT_ONLINE_FEEDS,
+				);
+
+				$baseUrl = $plxAdmin->racine . 'feed.php?admin' . $plxAdmin->aConf['clef'] . '/commentaires/';
+				foreach($options as $k=>$caption) {
+?>
+					<li><a href="<?= $baseUrl . $k ?>" title="<?= $caption ?>" download><?= $caption ?></a><i class="icon-rss"></i></li>
+<?php
+				}
+?>
+				</ul>
+			</span>
 <?php
 }
 ?>
+		</div>
+	</div>
 	<div class="scrollable-table<?= $hasPagination ? ' has-pagination' : '' ?>">
 		<table id="comments-table" class="full-width">
 			<thead>
@@ -209,13 +237,13 @@ if(!empty($portee)) {
 					<td><input type="checkbox" name="idCom[]" value="<?= $id ?>" /></td>
 					<td class="datetime"><?= plxDate::formatDate($plxAdmin->plxRecord_coms->f('date')) ?></td>
 <?php
-				if($all) {
+					if($all) {
 ?>
 					<td class="status"><?= empty($status) ? L_COMMENT_ONLINE : L_COMMENT_OFFLINE ?></td>
 <?php
-				}
+					}
 ?>
-					<td class="wrap"><?= nl2br($plxAdmin->plxRecord_coms->f('content')) ?></td>
+					<td class="wrap"><div><?= nl2br($plxAdmin->plxRecord_coms->f('content')) ?></div></td>
 					<td class="author"><?php
 					$author = $plxAdmin->plxRecord_coms->f('author');
 					$mail = $plxAdmin->plxRecord_coms->f('mail');
@@ -238,11 +266,11 @@ if(!empty($portee)) {
 						<a href="comment.php?<?= $query ?>" title="<?= L_COMMENT_EDIT_TITLE ?>"><?= L_COMMENT_EDIT ?></a>
 					</td>
 <?php
-			if(empty($portee)) {
+					if(empty($portee)) {
 ?>
 					<td class="action text-right"><a href="article.php?a=<?= $artId ?>" title="<?= L_COMMENT_ARTICLE_LINKED_TITLE ?>"><?= ltrim($artId, '0') ?></a></td>
 <?php
-}
+					}
 ?>
 				</tr>
 <?php
@@ -258,11 +286,10 @@ if(!empty($portee)) {
 				</tr>
 <?php
 			}
-			?>
+?>
 			</tbody>
 		</table>
 	</div>
-
 </form>
 <?php
 if($hasPagination) {
@@ -279,28 +306,6 @@ if($hasPagination) {
 </div>
 <?php
 }
-
-if(!empty($plxAdmin->aConf['clef'])) {
-?>
-<ul class="unstyled-list">
-	<li><?= L_COMMENTS_PRIVATE_FEEDS ?> :</li>
-<?php
-	$options = array(
-		'hors-ligne'	=> L_COMMENT_OFFLINE_FEEDS,
-		'en-ligne'		=> L_COMMENT_ONLINE_FEEDS,
-	);
-
-	$baseUrl = $plxAdmin->racine . 'feed.php?admin' . $plxAdmin->aConf['clef'] . '/commentaires/';
-	foreach($options as $k=>$caption) {
-?>
-	<li><a href="<?= $baseUrl . $k ?>" title="<?= $caption ?>" download><?= $caption ?></a></li>
-<?php
-}
-?>
-</ul>
-<?php
-}
-
 # Hook Plugins
 eval($plxAdmin->plxPlugins->callHook('AdminCommentsFoot'));
 

--- a/core/admin/index.php
+++ b/core/admin/index.php
@@ -306,7 +306,7 @@ if(!preg_match('#^\d{3}$#', $userId)) {
 				if(sizeof($catIds) > 0) {
 					foreach($catIds as $catId) {
 						if($catId == 'draft') {
-							$draft = ' - <strong>'.L_CATEGORY_DRAFT.'</strong>';
+							$draft = ' <strong>- '.L_CATEGORY_DRAFT.'</strong>';
 						} elseif(array_key_exists($catId, $aFilterCat)) {
 							$selected = ($catId==$_SESSION['sel_cat'] ? ' selected="selected"' : '');
 							$aCats[$catId] = <<< EOT
@@ -317,7 +317,7 @@ EOT;
 				}
 				# en attente de validation ?
 				$idArt = $plxAdmin->plxRecord_arts->f('numero');
-				$awaiting = $idArt[0]=='_' ? ' - <strong>'.L_AWAITING.'</strong>' : '';
+				$awaiting = $idArt[0]=='_' ? ' <strong>- '.L_AWAITING.'</strong>' : '';
 				# Commentaires
 				$nbComsToValidate = $plxAdmin->getNbCommentaires('/^_'.$idArt.'.(.*).xml$/','all');
 				$nbComsValidated = $plxAdmin->getNbCommentaires('/^'.$idArt.'.(.*).xml$/','all');

--- a/core/admin/medias.php
+++ b/core/admin/medias.php
@@ -191,21 +191,21 @@ if($curFolders) {
 			<input type="hidden" name="sort" value="" />
 			<?= plxToken::getTokenPostMethod() ?>
 		</div>
-
-		<div style="float:left">
-			<?= L_MEDIAS_FOLDER ?>&nbsp;:&nbsp;<?php $plxMedias->contentFolder() ?>
-			<input type="submit" name="btn_changefolder" value="<?= L_OK ?>" /><span class="sml-hide med-show">&nbsp;&nbsp;&nbsp;</span>
-		</div>
-
-		<div style="float:right">
-			<input type="text" id="medias-search" onkeyup="plugFilter()" placeholder="<?= L_SEARCH ?>..." title="<?= L_SEARCH ?>" />
+		<div class="grid">
+			<div class="col sml-6">
+				<?= L_MEDIAS_FOLDER ?>&nbsp;:&nbsp;<?php $plxMedias->contentFolder() ?>
+				<input type="submit" name="btn_changefolder" value="<?= L_OK ?>" />
+			</div>
+			<div class="col sml-6 text-right">
+				<input type="text" id="medias-search" onkeyup="plugFilter()" placeholder="<?= L_SEARCH ?>..." title="<?= L_SEARCH ?>" />
+			</div>
 		</div>
 <?php
 
 /* ============== listing of medias ============== */
 
 ?>
-		<div style="clear:both" class="scrollable-table">
+		<div class="scrollable-table">
 			<table id="medias-table" class="full-width sort">
 				<thead>
 				<tr>

--- a/core/admin/parametres_plugins.php
+++ b/core/admin/parametres_plugins.php
@@ -47,50 +47,53 @@ function pluginsList($plugins, $defaultLang, $type) {
 			if(empty($plugInstance) and $plugInstance=$plxAdmin->plxPlugins->getInstance($plugName)) {
 				$plugInstance->getInfos();
 			}
+
+			# plugin non configuré
+			$unset = ($type AND file_exists(PLX_PLUGINS.$plugName.'/config.php') AND !file_exists(PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.$plugName.'.xml'));
 ?>
-			<tr class="top" data-scope="<?= $plugInstance->getInfo('scope') ?>">
+			<tr class="top<?=$unset?' alert red':''?>" data-scope="<?= $plugInstance->getInfo('scope') ?>">
 				<td>
 					<input type="hidden" name="plugName[]" value="<?= $plugName ?>" />
 					<input type="checkbox" name="chkAction[]" value="<?= $plugName ?>" />
 				</td>
 <?php /* icon */ ?>
-				<td><img src="<?= $icon ?>" alt="" /></td>
+				<td><img src="<?= $icon ?>" alt="<?= $plugName ?> icon" /></td>
 <?php /* plugin infos */ ?>
 				<td class="wrap">
 					<p>
 <?php
-					# message d'alerte si plugin non configuré
-					if($type AND file_exists(PLX_PLUGINS.$plugName.'/config.php') AND !file_exists(PLX_ROOT.PLX_CONFIG_PATH.'plugins/'.$plugName.'.xml')) {
-?>
-					<span style="margin-top: 5px;" class="alert red float-right"><?= L_PLUGIN_NO_CONFIG ?></span>
-<?php
-					}
 					# title + version
 ?>
-					<strong><?= plxUtils::strCheck($plugInstance->getInfo('title')) ?></strong> - <?= L_PLUGINS_VERSION ?><strong> <?= plxUtils::strCheck($plugInstance->getInfo('version')) ?></strong>
+						<strong><?= plxUtils::strCheck($plugInstance->getInfo('title')) ?></strong><strong> - <?= L_PLUGINS_VERSION ?> <?= plxUtils::strCheck($plugInstance->getInfo('version')) ?></strong>
 <?php
 					# date
 					if($plugInstance->getInfo('date') != '') {
 ?>
-					(<?= plxUtils::strCheck($plugInstance->getInfo('date')) ?>)
+						<span>(<?= plxUtils::strCheck($plugInstance->getInfo('date')) ?>)</span>
+<?php
+					}
+?>
+					</p>
+<?php
+					# message d'alerte si plugin non configuré
+					if($unset) {
+?>
+					<p><a title="<?= L_PLUGINS_CONFIG_TITLE ?>" href="parametres_plugin.php?p=<?= urlencode($plugName) ?>"><b class="text-blue"><?= L_PLUGIN_NO_CONFIG ?></b></a></p>
 <?php
 					}
 					# description
 ?>
-					</p>
 					<p class="description"><?= plxUtils::strCheck($plugInstance->getInfo('description')) ?></p>
 <?php /* author */ ?>
-					<p>
-					<?= L_PLUGINS_AUTHOR ?> : <?= plxUtils::strCheck($plugInstance->getInfo('author')) ?>
+					<p><?= L_PLUGINS_AUTHOR ?> : <?= plxUtils::strCheck($plugInstance->getInfo('author')) ?></p>
 <?php
 					# site
-					if($plugInstance->getInfo('site')!='') {
+					if($site = plxUtils::strCheck($plugInstance->getInfo('site'))) {
 ?>
- - <a href="<?= plxUtils::strCheck($plugInstance->getInfo('site')) ?>" target="_blank"><?= plxUtils::strCheck($plugInstance->getInfo('site')) ?></a>
+					<p><a href="<?= $site ?>" title="<?= $site ?>" target="_blank"><?= $site ?></a></p>
 <?php
 					}
 ?>
-					</p>
 				</td>
 <?php
 				# colonne pour trier les plugins
@@ -223,7 +226,7 @@ if($sel==1) {
 					<th>&nbsp;</th>
 					<th><input type="text" id="plugins-search" onkeyup="plugFilter()" placeholder="<?= L_SEARCH ?>..." title="<?= L_SEARCH ?>" /></th>
 					<?php if($_SESSION['selPlugins']=='1') : ?>
-					<th><?= L_PLUGINS_LOADING_SORT ?></th>
+					<th title="<?= L_PLUGINS_LOADING_SORT ?>"><i class="icon-cog-alt"></i></th>
 					<?php endif; ?>
 					<th><?= L_PLUGINS_ACTION ?></th>
 				</tr>

--- a/core/admin/theme/plucss.css
+++ b/core/admin/theme/plucss.css
@@ -899,59 +899,6 @@ a:hover.tooltip-left span {
 	margin-right: 15px;
 }
 
-/* ---------- HELPER ---------- */
-
-.text-left {
-	text-align: left;
-}
-.text-center {
-	text-align: center;
-}
-.text-right {
-	text-align: right;
-}
-.text-justify {
-	text-align: justify;
-}
-.float-left {
-	float: left;
-}
-.float-center {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-}
-.float-right {
-	float: right;
-}
-.float-none {
-	float: none;
-}
-.show {
-	display: initial;
-}
-.hide {
-	display: none;
-}
-.full-width {
-	width: 100%;
-}
-.width-auto {
-	width: auto;
-}
-.no-margin {
-	margin: 0;
-}
-.no-padding {
-	padding: 0;
-}
-.sticky {
-	position: fixed;
-	position: -webkit-sticky;
-	position: sticky;
-	top: 0;
-}
-
 /* ---------- GRID, GALLERY, AND HELPER ---------- */
 
 .container {
@@ -1691,6 +1638,59 @@ a:hover.tooltip-left span {
 	.lrg-no-padding {
 		padding: 0;
 	}
+}
+
+/* ---------- HELPER ---------- */
+
+.text-left {
+	text-align: left;
+}
+.text-center {
+	text-align: center;
+}
+.text-right {
+	text-align: right;
+}
+.text-justify {
+	text-align: justify;
+}
+.float-left {
+	float: left;
+}
+.float-center {
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+}
+.float-right {
+	float: right;
+}
+.float-none {
+	float: none;
+}
+.show {
+	display: initial;
+}
+.hide {
+	display: none;
+}
+.full-width {
+	width: 100%;
+}
+.width-auto {
+	width: auto;
+}
+.no-margin {
+	margin: 0 !important;
+}
+.no-padding {
+	padding: 0 !important;
+}
+.sticky {
+	position: fixed;
+	position: -webkit-sticky;
+	position: sticky;
+	top: 0;
 }
 
 @media print {

--- a/core/admin/theme/theme.css
+++ b/core/admin/theme/theme.css
@@ -363,48 +363,20 @@ input[maxlength="3"] {
   width: 12rem;
 }
 
-#articles-table td:nth-child(4),
-#comments-table td:nth-child(4),
-#medias-table td:nth-child(3),
-#plugins-table td:nth-child(3) {
-	/* width: 100%; */
-	/* min-width: 200px; */
-	/* Mozilla, since 1999 */
-	white-space: -moz-pre-wrap !important;
-	/*Chrome & Safari */
-	white-space: -webkit-pre-wrap;
-	/* Opera 4-6 */
-	white-space: -pre-wrap;
-	/* Opera 7 */
-	white-space: -o-pre-wrap;
-	/* css-3 */
-	white-space: pre-wrap;
-	/* Internet Explorer 5.5+ */
-	word-wrap: break-word;
-	word-break: break-all;
-	/* white-space: normal; */
-	white-space: nowrap;
-}
-
 #plugins-table p {
 	margin: 0;
 	text-indent: 0;
 }
 
 #plugins-table .description {
-	white-space: normal;
-	word-break: normal;
-	text-align: justify;
+	overflow: scroll;
+	text-overflow: ellipsis ellipsis;
 }
 
 #plugins-table img,
 #medias-table img {
 	max-width: 48px;
 	padding-top: 7px;
-}
-
-#medias-table {
-	margin-top: 10px;
 }
 
 #medias-table td:nth-of-type(5) {
@@ -430,7 +402,8 @@ input[maxlength="3"] {
 	color: #444;
 }
 .toggler + label span:first-of-type, /* masquer */
-.toggler + label + div {
+.toggler + label + div,
+.toggler + label + span {
 	display: none;
 }
 .toggler + label span:last-of-type {
@@ -439,8 +412,9 @@ input[maxlength="3"] {
 .toggler:checked + label span:first-of-type { /* afficher */
 	display: inline-block;
 }
-.toggler:checked + label + div {
-	display: block;
+.toggler:checked + label + div,
+.toggler:checked + label + span {
+	display: initial;
 }
 .toggler:checked + label span:last-of-type {
 	display: none;
@@ -691,10 +665,22 @@ tr input {
 
 td {
 	white-space: nowrap;
+	overflow: hidden;
 }
 
+/* ---- index, comments, plugins tables ---- */
 td.wrap {
-	white-space: normal;
+	white-space: nowrap;
+	max-width: 45.6vw;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+td.wrap a,
+td.wrap p,
+td.wrap > * {
+	display: block;
+	overflow: scroll;
+	text-overflow: ellipsis ellipsis;
 }
 
 th.checkbox {
@@ -849,6 +835,9 @@ th.sort.active::after {
 		right: 0;
 		top: 2rem;
 	}
+	td.wrap {
+		max-width: 30vw;
+	}
 }
 
 .modal label:hover {
@@ -928,6 +917,8 @@ tr.checked {
 #plugins-search {
 	background: url('images/search.png') 5px 7px no-repeat;
 	padding-left: 30px;
+	max-width: 20rem;
+	width: 100%;
 }
 
 /* gestionnaire de médias */
@@ -937,7 +928,7 @@ div.ico {
 	color: #ccc;
 	display: inline-block;
 	margin-left: 5px;
-	position: relative;
+	position: initial;
 }
 
 div.ico:hover {
@@ -1106,7 +1097,9 @@ select {
 select::-ms-expand {/*for IE10*/
 	display: none;
 }
-
+#files_manager select{
+	max-width: 55%;
+}
 /* ---- parametres_plugins ---- */
 
 #form_plugins span[data-scope] {
@@ -1117,6 +1110,7 @@ select::-ms-expand {/*for IE10*/
 #plugins-table tbody tr[data-scope] td.wrap strong:first-of-type {
 	padding: 0.2rem 0.5rem;
 	background-color: #ddd;
+	color: #444;
 }
 
 #form_plugins span[data-scope="admin"],


### PR DESCRIPTION
Flux des Commentaires privés en haut et dépliable

Page des articles `- brouillons` en dessous du lien (si trop long) 

Page des plugins retravaillée et harmonieuse

Page des médias grid des sélecteur et recherche

theme.css toggler inline et simplifié + #744 en prévision 

Helpers de PluCss redescendus (no-padding & no-margin)

Voir historique #714 pour plus d'info et les visuels