### PR TITLE
Simplifie com id : #c0001-10 > #c10 & fix admin/comment link

### DIFF
--- a/core/lib/class.plx.feed.php
+++ b/core/lib/class.plx.feed.php
@@ -357,7 +357,7 @@ class plxFeed extends plxMotor {
 				# Traitement initial
 				if(isset($this->activeArts[$this->plxRecord_coms->f('article')])) {
 					$artId = $this->plxRecord_coms->f('article') + 0;
-					$comId = 'c'.$this->plxRecord_coms->f('article').'-'.$this->plxRecord_coms->f('index');
+					$comId = 'c'.$this->plxRecord_coms->f('index');
 					if($this->cible) { # Commentaires d'un article
 						$title_com = $this->plxRecord_arts->f('title').' - ';
 						$title_com .= L_FEED_WRITTEN_BY.' '.$this->plxRecord_coms->f('author').' @ ';

--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -405,7 +405,7 @@ class plxMotor {
 				# Url de l'article
 				$url = $this->urlRewrite('?article'.intval($this->plxRecord_arts->f('numero')).'/'.$this->plxRecord_arts->f('url'));
 				eval($this->plxPlugins->callHook('plxMotorDemarrageNewCommentaire')); # Hook Plugins
-				if(preg_match('~^c\d{4}-\d+~', $retour)) { # Le commentaire a été publié
+				if(preg_match('~^c\d+~', $retour)) { # Le commentaire a été publié
 					$_SESSION['msgcom'] = L_COM_PUBLISHED;
 					header('Location: '.$url.'#'.$retour);
 				} elseif($retour == 'mod') { # Le commentaire est en modération

--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -1102,7 +1102,7 @@ class plxMotor {
 
 				# On peut créer le commentaire
 				if($this->addCommentaire($comment)) { # Commentaire OK
-					return $this->aConf['mod_com'] ? 'mod' : 'c' . $artId . '-' . $idx;
+					return $this->aConf['mod_com'] ? 'mod' : 'c' . $idx;
 				} else { # Erreur lors de la création du commentaire
 					return L_NEWCOMMENT_ERR;
 				}

--- a/core/lib/class.plx.show.php
+++ b/core/lib/class.plx.show.php
@@ -1308,7 +1308,7 @@ class plxShow
 	 **/
 	public function comId($echo = true)
 	{
-		$id = 'c' . $this->plxMotor->plxRecord_coms->f('article') . '-' . $this->plxMotor->plxRecord_coms->f('index');
+		$id = 'c' . $this->plxMotor->plxRecord_coms->f('index');
 		if ($echo)
 			echo $id;
 		else
@@ -1585,7 +1585,7 @@ class plxShow
 					$artInfo = $this->plxMotor->artInfoFromFilename($this->plxMotor->plxGlob_arts->aFiles[$com['article']]);
 					if ($artInfo['artDate'] <= $datetime) { # on ne prends que les commentaires pour les articles publiés
 						if (empty($cat_ids) or preg_match('/(' . $cat_ids . ')/', $artInfo['catId'])) {
-							$url = '?article' . intval($com['article']) . '/' . $artInfo['artUrl'] . '#c' . $com['article'] . '-' . $com['index'];
+							$url = '?article' . intval($com['article']) . '/' . $artInfo['artUrl'] . '#c' . $com['index'];
 							$date = $com['date'];
 							$content = strip_tags($com['content']);
 							# On modifie nos motifs
@@ -2008,9 +2008,9 @@ class plxShow
 		# Hook Plugins
 		if (eval($this->plxMotor->plxPlugins->callHook('plxShowCapchaQ'))) return;
 		echo $this->plxMotor->plxCapcha->q();
-		?>
+?>
 		<input type="hidden" name="capcha_token" value="<?= $_SESSION['capcha_token'] ?>"/>
-		<?php
+<?php
 	}
 
 	/**


### PR DESCRIPTION
Annonymise l'Id de l'article ds l'ancre publique du site (peut-être utile avec MyBetterUrl)

Fixe des erreurs de 2015
[mauvais index dans le lien des commentaires (2015.10.22)](https://github.com/pluxml/PluXml/commit/c03af6b5060695e98afa76952dfa2f7fb5309485) et
[refonte gestion des commentaires (2015.09.03)](https://github.com/pluxml/PluXml/commit/3371e108a3c381fb38b4d865a90ba3aeb8471894)

Donc le lien admin/comment.php est en panne depuis ce temps là 
https://github.com/pluxml/PluXml/blob/b09117cf731b73f9b56eb417f813db3dfdb399b4/core/admin/comment.php#L104

Ou alors ajouter $artId.'-' qui manque a la ligne ci-dessus 
`'/#c'.$artId.'-'.$plxAdmin...`