### PR TITLE
plxGlob Good com timestamp to compare with $now

### DIFF
--- a/core/lib/class.plx.glob.php
+++ b/core/lib/class.plx.glob.php
@@ -172,15 +172,17 @@ class plxGlob {
 						case 'com':
 							# Tri selon les dates de publications (commentaire)
 							$key = $index[1] . $index[0];
+							# On extrait le timestamp de l'index 1 (1234567890-2)
+							$index = explode('-',$index[1]);
 							# On cree un tableau associatif en choisissant bien nos cles et en verifiant la date de publication
 							switch($publi) {
 								case'before':
-									if($index[1] <= $now) {
+									if($index[0] <= $now) {
 										$array[$key] = $file;
 									}
 									break;
 								case 'after':
-									if($index[1] >= $now) {
+									if($index[0] >= $now) {
 										$array[$key] = $file;
 									}
 									break;


### PR DESCRIPTION
IDART.TIMESTAMP-IDCOM.xml
0002.1234567890-2.xml
Index1: 1234567890-2
Index0: 0002
KEY: 1234567890-20002

Fix last com posted it's invisible after post
and reuse $index beacause just used after for compare with $now

See line 137
```
					# On decoupe le nom du fichier
					$index = explode('.',$file);
```