### PR TITLE
Fix php8.2 using ${var} in strings is deprecated

### DIFF
--- a/core/admin/comments.php
+++ b/core/admin/comments.php
@@ -85,7 +85,7 @@ $options = array(
 	'offline'	=> L_COMMENT_OFFLINE,
 );
 $h2 = <<< EOT
-<h2>${options[$comSel]}</h2>
+<h2>{$options[$comSel]}</h2>
 EOT;
 
 $comSelMotif = '/^' . $mods[$comSel] . $artMotif . '\..*\.xml$/';

--- a/core/admin/index.php
+++ b/core/admin/index.php
@@ -311,7 +311,7 @@ if(!preg_match('#^\d{3}$#', $userId)) {
 						} elseif(array_key_exists($catId, $aFilterCat)) {
 							$selected = ($catId==$_SESSION['sel_cat'] ? ' selected="selected"' : '');
 							$aCats[$catId] = <<< EOT
-<option value="$catId" $selected> ${aFilterCat[$catId]} </option>
+<option value="$catId" $selected> {$aFilterCat[$catId]} </option>
 EOT;
 						}
 					}


### PR DESCRIPTION
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/core/admin/index.php on line 314
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/core/admin/comments.php on line 88