### PR TITLE
Fix for old plugins without plxMotorDemarrageBegin Hook

### DIFF
--- a/core/lib/class.plx.motor.php
+++ b/core/lib/class.plx.motor.php
@@ -463,7 +463,20 @@ class plxMotor {
 			case 'telechargement' :
 				break;
 			default :
-				$this->error404(L_ERR_PAGE_NOT_FOUND);
+				# rétro-compatibilité pour plugins orphelins qui ne gérent pas le hook plxMotorDemarrageBegin !!!
+				# Supprimer ce test dès que possible et appeler directement $this->erro404(...)
+				if(
+					!preg_match('#^(?:\.\./)*' . $this->aConf['racine_plugins'] . '([^/]+)#', $this->cible, $matches) or
+					!array_key_exists($matches[1], $this->plxPlugins->aPlugins) or
+					empty(array_filter(
+						$this->plxPlugins->aHooks['plxMotorPreChauffageBegin'],
+						function($value) use($matches) {
+							return ($value['class'] == $matches[1]);
+						}
+					))
+				) {
+					$this->error404(L_ERR_PAGE_NOT_FOUND);
+				}
 		}
 
 		# Hook plugins


### PR DESCRIPTION
See https://forum.pluxml.org/discussion/7574/pluxml-5-9-0/p3#Comment_64863

Some plugins, officials or not, use _plxMotorPreChauffageBegin_ hook without _plxMotorDemarrageBegin_ hook for using theirs own _plxMotor::mode_ and altering _plxMotor::cible_.
This commit prevents an 404 error in this case.
These plugins must be updated !! May be they are orpheans.