### PR TITLE
Fix in plxAdmin::getFileStatique() and plxPlugins::__construct()

### DIFF
--- a/core/lib/class.plx.admin.php
+++ b/core/lib/class.plx.admin.php
@@ -840,14 +840,15 @@ RewriteRule ^feed\/(.*)$ feed.php?$1 [L]
 		# Emplacement de la page
 		$filename = PLX_ROOT.$this->aConf['racine_statiques'].$num.'.'.$this->aStats[ $num ]['url'].'.php';
 		if(file_exists($filename) AND filesize($filename) > 0) {
-			if($f = fopen($filename, 'r')) {
-				$content = fread($f, filesize($filename));
-				fclose($f);
+			$content = file_get_contents($filename);
+			if(is_string($content)) {
 				# On retourne le contenu
 				return $content;
+			} else {
+				return implode(PHP_EOL, array('<p>', "\t" . L_UNKNOWN_ERROR, '</p>'));
 			}
 		}
-		return null;
+		return implode(PHP_EOL, array('<p>', "\t" . L_STATICS_NEW_PAGE, '</p>'));
 	}
 
 	/**

--- a/core/lib/class.plx.plugins.php
+++ b/core/lib/class.plx.plugins.php
@@ -26,7 +26,7 @@ class plxPlugins {
 
 		register_shutdown_function(function() {
 			$error = error_get_last();
-			if($error != null) {
+			if($error != null and !empty($error['file']) and (PLX_DEBUG or $error['type'] < E_DEPRECATED)) { # error['type'] < 8192
 				# For hiding sensitive informations
 				$documentRoot = realpath($_SERVER['DOCUMENT_ROOT']); # resolve symbolic link with Linux
 				$filename = $error['file'];
@@ -79,6 +79,7 @@ See https://www.php.net/manual/en/errorfunc.constants.php about type of error
 User : <?= $_SESSION['user'] . PHP_EOL ?>
 Profil : <?= $_SESSION['profil'] . PHP_EOL ?>
 PluXml version : <?= PLX_VERSION . PHP_EOL ?>
+PLX_DEBUG : <?= PLX_DEBUG ? 'true' : 'false' ?>
 PHP version : <?= PHP_VERSION . PHP_EOL ?>
 <?=	$hr ?>
 About this server :

--- a/core/lib/config.php
+++ b/core/lib/config.php
@@ -1,6 +1,6 @@
 <?php
 const PLX_DEBUG = true;
-const PLX_VERSION = '5.8.14';
+const PLX_VERSION = '5.8.15';
 const PLX_URL_REPO = 'https://www.pluxml.org';
 const PLX_URL_VERSION = PLX_URL_REPO.'/download/latest-version.txt';
 

--- a/readme/CHANGELOG
+++ b/readme/CHANGELOG
@@ -1,3 +1,8 @@
+## PLUXML 5.8.15 (2024/07/18)
+[+] plxAdmin::getFileStatique() always returns a string
+[+] PLX_DEBUG is set to "true"
+[+] In plxPlugins::__construct(), error is ignored in some cases
+
 ## PLUXML 5.8.14 (2024/05/15)
 [+] date_creation or date_update may be missing in a file of article
 


### PR DESCRIPTION
plxAdmin::getFileStatique() always returns a string

PLX_DEBUG is set to "true"

In plxPlugins::__construct(), error is ignored in some cases :
 - PLX_DEBUG is false
 - $error['file'] is empty
 - $error['type'] < E_DEPRECATED ( not warnings )

See :
- https://forum.pluxml.org/discussion/7669/fatal-error-type-8192-durant-edition-page-statique
- https://forum.pluxml.org/discussion/7674/php-request-shutdown-use-of-mbstring-http-input-is-deprecated