### PR TITLE
Update class.plx.utils.php

### DIFF
--- a/core/lib/class.plx.utils.php
+++ b/core/lib/class.plx.utils.php
@@ -1438,7 +1438,7 @@ class plxUtils {
 		/* Supprime les commentaires */
 		$buffer = preg_replace('!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $buffer);
 		/* Supprime les tabs, espaces, saut de ligne, etc. */
-		$buffer = str_replace(array("\r\n", "\r", "\n", "\t", '  ', '    ', '    '), '', $buffer);
+		$buffer = str_replace(array("\r\n", "\r", "\n", "\t", '  ', '    ', '    '), ' ', $buffer);
 		return $buffer;
 	}
 


### PR DESCRIPTION
Some tag selectors in css file are broken  once minified  `.class h3 span` turns into `.classh3span` then  included into site.css file on activating a plugin that has a site.css file. 

[fix]  keeps at least an empty space in between selectors and else

Probably not the best way since its applied to any kind of file minified.